### PR TITLE
fix: add react-dom into peerDependencies

### DIFF
--- a/.changeset/red-numbers-compete.md
+++ b/.changeset/red-numbers-compete.md
@@ -1,0 +1,21 @@
+---
+"@sipe-team/radio-group": patch
+"@sipe-team/typography": patch
+"@sipe-team/checkbox": patch
+"@sipe-team/skeleton": patch
+"@sipe-team/divider": patch
+"@sipe-team/tooltip": patch
+"@sipe-team/avatar": patch
+"@sipe-team/button": patch
+"@sipe-team/switch": patch
+"@sipe-team/input": patch
+"@sipe-team/badge": patch
+"@sipe-team/reset": patch
+"@sipe-team/card": patch
+"@sipe-team/flex": patch
+"@sipe-team/grid": patch
+"@sipe-team/icon": patch
+"@sipe-team/side": patch
+---
+
+fix: add react-dom into peerDependencies

--- a/.templates/component/package.json
+++ b/.templates/component/package.json
@@ -40,7 +40,8 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "react": ">= 18"
+    "react": ">= 18",
+    "react-dom": ">= 18"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/Input/package.json
+++ b/packages/Input/package.json
@@ -45,7 +45,8 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "react": ">= 18"
+    "react": ">= 18",
+    "react-dom": ">= 18"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -46,7 +46,8 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "react": ">= 18"
+    "react": ">= 18",
+    "react-dom": ">= 18"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -45,7 +45,8 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "react": ">= 18"
+    "react": ">= 18",
+    "react-dom": ">= 18"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -47,7 +47,8 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "react": ">= 18"
+    "react": ">= 18",
+    "react-dom": ">= 18"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -46,7 +46,8 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "react": ">= 18"
+    "react": ">= 18",
+    "react-dom": ">= 18"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -20,6 +20,11 @@
     "typecheck": "tsc",
     "prepack": "pnpm run build"
   },
+  "dependencies": {
+    "@radix-ui/react-slot": "^1.1.0",
+    "clsx": "^2.1.1",
+    "nanoid": "^5.0.9"
+  },
   "devDependencies": {
     "@storybook/addon-essentials": "catalog:",
     "@storybook/addon-interactions": "catalog:",
@@ -40,7 +45,8 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "react": ">= 18"
+    "react": ">= 18",
+    "react-dom": ">= 18"
   },
   "publishConfig": {
     "access": "public",
@@ -59,10 +65,5 @@
       "./styles.css": "./dist/index.css"
     }
   },
-  "sideEffects": false,
-  "dependencies": {
-    "@radix-ui/react-slot": "^1.1.0",
-    "clsx": "^2.1.1",
-    "nanoid": "^5.0.9"
-  }
+  "sideEffects": false
 }

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -20,6 +20,9 @@
     "typecheck": "tsc",
     "prepack": "pnpm run build"
   },
+  "dependencies": {
+    "clsx": "^2.1.1"
+  },
   "devDependencies": {
     "@sipe-team/typography": "workspace:*",
     "@storybook/addon-essentials": "catalog:",
@@ -41,7 +44,8 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "react": ">= 18"
+    "react": ">= 18",
+    "react-dom": ">= 18"
   },
   "publishConfig": {
     "access": "public",
@@ -59,8 +63,5 @@
       "./styles.css": "./dist/index.css"
     }
   },
-  "sideEffects": false,
-  "dependencies": {
-    "clsx": "^2.1.1"
-  }
+  "sideEffects": false
 }

--- a/packages/flex/package.json
+++ b/packages/flex/package.json
@@ -45,7 +45,8 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "react": ">= 18"
+    "react": ">= 18",
+    "react-dom": ">= 18"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -9,9 +9,7 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",
@@ -21,6 +19,10 @@
     "test": "vitest",
     "typecheck": "tsc",
     "prepack": "pnpm run build"
+  },
+  "dependencies": {
+    "@radix-ui/react-slot": "^1.1.0",
+    "clsx": "^2.1.1"
   },
   "devDependencies": {
     "@faker-js/faker": "^9.2.0",
@@ -42,7 +44,8 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "react": ">= 18"
+    "react": ">= 18",
+    "react-dom": ">= 18"
   },
   "publishConfig": {
     "access": "public",
@@ -61,9 +64,5 @@
       "./styles.css": "./dist/index.css"
     }
   },
-  "sideEffects": false,
-  "dependencies": {
-    "@radix-ui/react-slot": "^1.1.0",
-    "clsx": "^2.1.1"
-  }
+  "sideEffects": false
 }

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -42,7 +42,8 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "react": ">= 18"
+    "react": ">= 18",
+    "react-dom": ">= 18"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -42,7 +42,8 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "react": ">= 18"
+    "react": ">= 18",
+    "react-dom": ">= 18"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/reset/package.json
+++ b/packages/reset/package.json
@@ -20,6 +20,10 @@
     "typecheck": "tsc",
     "prepack": "pnpm run build"
   },
+  "dependencies": {
+    "@radix-ui/react-slot": "^1.1.0",
+    "classnames": "^2.5.1"
+  },
   "devDependencies": {
     "@storybook/addon-essentials": "catalog:",
     "@storybook/addon-interactions": "catalog:",
@@ -39,7 +43,8 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "react": ">= 18"
+    "react": ">= 18",
+    "react-dom": ">= 18"
   },
   "publishConfig": {
     "access": "public",
@@ -57,9 +62,5 @@
       }
     }
   },
-  "sideEffects": false,
-  "dependencies": {
-    "@radix-ui/react-slot": "^1.1.0",
-    "classnames": "^2.5.1"
-  }
+  "sideEffects": false
 }

--- a/packages/side/package.json
+++ b/packages/side/package.json
@@ -33,7 +33,8 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "react": ">= 18"
+    "react": ">= 18",
+    "react-dom": ">= 18"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -20,6 +20,9 @@
     "typecheck": "tsc",
     "prepack": "pnpm run build"
   },
+  "dependencies": {
+    "@radix-ui/react-slot": "^1.1.0"
+  },
   "devDependencies": {
     "@faker-js/faker": "^9.2.0",
     "@storybook/addon-essentials": "catalog:",
@@ -41,7 +44,8 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "react": ">= 18"
+    "react": ">= 18",
+    "react-dom": ">= 18"
   },
   "publishConfig": {
     "access": "public",
@@ -60,8 +64,5 @@
       "./styles.css": "./dist/index.css"
     }
   },
-  "sideEffects": false,
-  "dependencies": {
-    "@radix-ui/react-slot": "^1.1.0"
-  }
+  "sideEffects": false
 }

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -20,6 +20,10 @@
     "typecheck": "tsc",
     "prepack": "pnpm run build"
   },
+  "dependencies": {
+    "@sipe-team/tokens": "workspace:^",
+    "clsx": "^2.1.1"
+  },
   "devDependencies": {
     "@faker-js/faker": "^9.2.0",
     "@storybook/addon-essentials": "catalog:",
@@ -42,7 +46,8 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "react": ">= 18"
+    "react": ">= 18",
+    "react-dom": ">= 18"
   },
   "publishConfig": {
     "access": "public",
@@ -60,9 +65,5 @@
       "./styles.css": "./dist/index.css"
     }
   },
-  "sideEffects": false,
-  "dependencies": {
-    "@sipe-team/tokens": "workspace:^",
-    "clsx": "^2.1.1"
-  }
+  "sideEffects": false
 }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -47,7 +47,8 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "react": ">= 18"
+    "react": ">= 18",
+    "react-dom": ">= 18"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -46,7 +46,8 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "react": ">= 18"
+    "react": ">= 18",
+    "react-dom": ">= 18"
   },
   "publishConfig": {
     "access": "public",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -766,6 +766,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      react-dom:
+        specifier: '>= 18'
+        version: 18.3.1(react@18.3.1)
     devDependencies:
       '@faker-js/faker':
         specifier: ^9.2.0
@@ -944,6 +947,9 @@ importers:
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
+      react-dom:
+        specifier: '>= 18'
+        version: 18.3.1(react@18.3.1)
     devDependencies:
       '@storybook/addon-essentials':
         specifier: 'catalog:'
@@ -1035,6 +1041,9 @@ importers:
       react:
         specifier: '>= 18'
         version: 18.3.1
+      react-dom:
+        specifier: '>= 18'
+        version: 18.3.1(react@18.3.1)
     devDependencies:
       tsup:
         specifier: 'catalog:'


### PR DESCRIPTION
## Changes
- react-dom을 peerDependencies로 명시하지 않는 경우, 패키지를 사용하는 쪽에서 서로 다른 react-dom 버전을 설치했을 때 문제가 발생합니다. 이를 수정했어요.

## Visuals
<!-- If there are any screenshots or visual materials, please attach them. -->

## Checklist
- [ ] Have you written the functional specifications?
- [ ] Have you written the test code?

## Additional Discussion Points
<!-- If there are any additional points to be aware of, please specify them. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- 최신 React 환경과의 원활한 연동을 위해 모든 UI 컴포넌트가 React와 React-DOM(버전 18 이상) 요구사항을 준수하도록 업데이트되었습니다.
	- 일부 컴포넌트에 추가 보조 라이브러리가 도입되어 전반적인 성능과 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->