### PR TITLE
feat(plugin-figma-codegen): add figma codegen plugin

### DIFF
--- a/packages/plugin-figma-codegen/manifest.json
+++ b/packages/plugin-figma-codegen/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "@sipe-team/plugin-figma-codegen",
+  "api": "1.0.0",
+  "capabilities": ["codegen", "vscode"],
+  "codegenLanguages": [{ "label": "React", "value": "react" }],
+  "editorType": ["dev"],
+  "id": "1477931843428059075",
+  "main": "dist/index.js"
+}

--- a/packages/plugin-figma-codegen/package.json
+++ b/packages/plugin-figma-codegen/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@sipe-team/plugin-figma-codegen",
+  "description": "Figma codegen plugin for Sipe Design System",
+  "version": "0.0.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sipe-team/side"
+  },
+  "type": "module",
+  "exports": "./src/index.ts",
+  "files": ["dist", "manifest.json"],
+  "scripts": {
+    "build": "tsup",
+    "dev": "pnpm build --watch",
+    "lint": "biome lint .",
+    "typecheck": "tsc",
+    "prepack": "pnpm run build"
+  },
+  "devDependencies": {
+    "@figma/plugin-typings": "^1.108.0",
+    "tsup": "catalog:",
+    "typescript": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://npm.pkg.github.com",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "sideEffects": false
+}

--- a/packages/plugin-figma-codegen/src/index.ts
+++ b/packages/plugin-figma-codegen/src/index.ts
@@ -1,0 +1,22 @@
+if (figma.editorType !== 'dev' || figma.mode !== 'codegen') {
+  figma.closePlugin();
+}
+
+figma.codegen.on('generate', async ({ node }) => {
+  const ComponentName = node.name;
+
+  if (node.type === 'INSTANCE') {
+    const props = node.componentProperties;
+    const result = Object.entries(props).map(([name, { value }]) => `${name}="${value}"`);
+
+    return [
+      {
+        title: ComponentName,
+        language: 'TYPESCRIPT',
+        code: `<${ComponentName} ${result.join(' ')} />`,
+      },
+    ];
+  }
+
+  return [];
+});

--- a/packages/plugin-figma-codegen/tsconfig.json
+++ b/packages/plugin-figma-codegen/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "typeRoots": ["./node_modules/@types", "./node_modules/@figma"]
+  }
+}

--- a/packages/plugin-figma-codegen/tsup.config.ts
+++ b/packages/plugin-figma-codegen/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  clean: true,
+  dts: true,
+  format: 'esm',
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -888,6 +888,18 @@ importers:
         specifier: 'catalog:'
         version: 2.1.8(@types/node@22.10.1)(happy-dom@15.11.7)(terser@5.37.0)
 
+  packages/plugin-figma-codegen:
+    devDependencies:
+      '@figma/plugin-typings':
+        specifier: ^1.108.0
+        version: 1.108.0
+      tsup:
+        specifier: 'catalog:'
+        version: 8.3.5(jiti@2.4.1)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.1)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.6.3
+
   packages/radio-group:
     devDependencies:
       '@storybook/addon-essentials':
@@ -3195,6 +3207,9 @@ packages:
   '@faker-js/faker@9.2.0':
     resolution: {integrity: sha512-ulqQu4KMr1/sTFIYvqSdegHT8NIkt66tFAkugGnHA+1WAfEn6hMzNR+svjXGFRVLnapxvej67Z/LwchFrnLBUg==}
     engines: {node: '>=18.0.0', npm: '>=9.0.0'}
+
+  '@figma/plugin-typings@1.108.0':
+    resolution: {integrity: sha512-hZocQwkMUfQZSa/6H9qkSkIKMDC70OOcV8U7hBocAsD/bWEZh13uj+aP6IHHmStscoavo9Ir5pU7NWEUUcXLug==}
 
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -11685,6 +11700,8 @@ snapshots:
       levn: 0.4.1
 
   '@faker-js/faker@9.2.0': {}
+
+  '@figma/plugin-typings@1.108.0': {}
 
   '@hapi/hoek@9.3.0': {}
 


### PR DESCRIPTION
## Changes
- Add basic Side component codegen plugin for Figma.

## Visuals
![스크린샷 12](https://github.com/user-attachments/assets/99d13938-f416-49a1-99f7-8eaa8d27ab7c)

## Checklist
- [ ] Have you written the functional specifications?
- [ ] Have you written the test code?

## Additional Discussion Points
<!-- If there are any additional points to be aware of, please specify them. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 새로운 플러그인 메타데이터를 도입하여 플러그인 기능과 지원 언어를 명확하게 정의했습니다.
	- 디자인 요소를 기반으로 컴포넌트 코드 생성을 자동화하는 기능이 추가되었습니다.
- **Chores**
	- 개발과 배포를 원활하게 하는 구성 및 설정 파일들이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->