### PR TITLE
ci(storybook): add workflow for storybook deployment

### DIFF
--- a/.github/workflows/storybook-deploy.yaml
+++ b/.github/workflows/storybook-deploy.yaml
@@ -1,0 +1,38 @@
+name: Deploy Storybook
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**/*.stories.@(js|jsx|ts|tsx)'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+      - name: creates output
+        run: sh ./build.sh
+      - name: Copy .storybook folder
+        run: cp -r .storybook output/
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.GH_TOKEN }}
+          DESTINATION_USERNAME: "froggy1014"
+          DESTINATION_REPO: "side-storybook"
+        with:
+          source-directory: "output"
+          destination-github-username: ${{ env.DESTINATION_USERNAME }}
+          destination-repository-name: ${{ env.DESTINATION_REPO }}
+          user-email: ${{ secrets.EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: main
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+cd ../
+mkdir output
+
+cp -r .storybook output/
+cp -R ./side/* ./output
+cp -R ./output ./side/


### PR DESCRIPTION
## Changes

1. 오가니제이션에 속해있는 퍼블릭 레포지토리에 대해서는 Vercel에서 1개 이상 Hobby Plan으로는 불가능합니다. 
    > 2개 이상부터는 Pro plan($20/seat)

2. 개인의 레포에서 올리는건 가능하기때문에, [퍼블릭 레포](https://github.com/froggy1014/side-storybook)를 하나 판다음에,   여기서 워크플로우를 통해 해당 레포지토리로 코드를 동기화해주면 버셀에 무료로 호스팅이 가능할 것으로 보입니다. ( 테스트 완료 ) 

필요한 Secret 값들은 이미 넣어놓은 상태입니다. 

> P.S 서브도메인도 연결되는 것도 확인한 상태입니다. 

## Checklist
- [ ] Have you written the functional specifications?
- [ ] Have you written the test code?

## Reference 

- https://velog.io/@rmaomina/organization-vercel-hobby-deploy
