### PR TITLE
chore(workflow): add fallback commit msg for workflow_dispatch

### DIFF
--- a/.github/workflows/storybook-deploy.yaml
+++ b/.github/workflows/storybook-deploy.yaml
@@ -1,0 +1,38 @@
+name: Deploy Storybook
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**/*.stories.@(js|jsx|ts|tsx)'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+      - name: creates output
+        run: sh ./build.sh
+      - name: Copy .storybook folder
+        run: cp -r .storybook output/
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.GH_TOKEN }}
+          DESTINATION_USERNAME: "froggy1014"
+          DESTINATION_REPO: "side-storybook"
+        with:
+          source-directory: "output"
+          destination-github-username: ${{ env.DESTINATION_USERNAME }}
+          destination-repository-name: ${{ env.DESTINATION_REPO }}
+          user-email: ${{ secrets.EMAIL }}
+          commit-message: ${{ github.event.commits[0].message || 'Manual deployment via workflow_dispatch' }}
+          target-branch: main
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY


### PR DESCRIPTION
## Changes

workflow_dispatch로 깃액션을 실행할때, placeholder 커밋메세지가 필요해서 추가했습니다. 

- https://github.com/sipe-team/side/actions/runs/13869587806

<img width="312" alt="image" src="https://github.com/user-attachments/assets/18621624-9847-4d0a-846c-9f6d3f62116c" />


## Visuals
<!-- If there are any screenshots or visual materials, please attach them. -->

## Checklist
- [ ] Have you written the functional specifications?
- [ ] Have you written the test code?

## Additional Discussion Points
<!-- If there are any additional points to be aware of, please specify them. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 배포 자동화 프로세스의 안정성을 높여, 수동 배포 시에도 일관된 처리가 이루어지도록 개선하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->