### PR TITLE
docs(storybook): update grid story title to include component path

### DIFF
--- a/packages/grid/src/Grid.stories.tsx
+++ b/packages/grid/src/Grid.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import * as Grid from './Grid';
 
 const meta = {
-  title: 'Grid',
+  title: 'Components/Grid',
   component: Grid.Root,
   tags: ['autodocs'],
   parameters: {


### PR DESCRIPTION
## Changes
- update grid story title to include component path

## Visuals
**[before]**

<img width="288" alt="image" src="https://github.com/user-attachments/assets/37278163-fc45-48f6-b7fb-408e8af59fbd" />

**[after]**

<img width="293" alt="image" src="https://github.com/user-attachments/assets/a5385b1c-172d-4a76-8196-fe2402efa9b9" />

## Checklist
- [ ] Have you written the functional specifications?
- [ ] Have you written the test code?

## Additional Discussion Points
- How about separating components by category in Storybook?
ex) `Grid`, `Flex` - `Components` => `Components/Layout"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 스토리북 내에서 그리드 컴포넌트의 범주명이 'Components/Grid'로 업데이트되어, 구성 요소 라이브러리에서 보다 체계적인 분류가 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->