### PR TITLE
refactor(badge): apply vanilla-extract

### DIFF
--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -9,9 +9,7 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",
@@ -23,6 +21,7 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
+    "@sipe-team/tokens": "workspace:*",
     "@sipe-team/typography": "workspace:*",
     "clsx": "^2.1.1"
   },
@@ -37,6 +36,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",
     "@types/react": "^18.3.12",
+    "@vanilla-extract/css": "catalog:",
     "happy-dom": "catalog:",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/packages/badge/src/Badge.css.ts
+++ b/packages/badge/src/Badge.css.ts
@@ -1,5 +1,5 @@
 import { style, styleVariants } from '@vanilla-extract/css';
-import { fontSize as fontSizeToken } from '@sipe-team/tokens';
+import { color as colorToken, fontSize as fontSizeToken } from '@sipe-team/tokens';
 
 // Define the types for our component
 export const BadgeSize = {
@@ -51,21 +51,21 @@ export const fontSize = styleVariants({
 // Variant styles
 export const variant = styleVariants({
   [BadgeVariant.filled]: {
-    backgroundColor: '#2D3748',
+    backgroundColor: colorToken.cyan900,
     border: 'none',
   },
   [BadgeVariant.outline]: {
     backgroundColor: 'transparent',
-    border: '2px solid #2D3748',
+    border: `2px solid ${colorToken.cyan900}`,
   },
   [BadgeVariant.weak]: {
-    backgroundColor: '#EDF2F7',
+    backgroundColor: colorToken.gray200,
     border: 'none',
   },
 });
 
 // Text style
 export const text = style({
-  color: '#00FFFF',
+  color: colorToken.cyan300,
   fontWeight: 600,
 });

--- a/packages/badge/src/Badge.css.ts
+++ b/packages/badge/src/Badge.css.ts
@@ -1,0 +1,71 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+import { fontSize as fontSizeToken } from '@sipe-team/tokens';
+
+// Define the types for our component
+export const BadgeSize = {
+  small: 'small',
+  medium: 'medium',
+  large: 'large',
+} as const;
+
+export const BadgeVariant = {
+  filled: 'filled',
+  outline: 'outline',
+  weak: 'weak',
+} as const;
+
+// Base styles for the badge
+export const root = style({
+  borderRadius: 8,
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+});
+
+// Size variants
+export const size = styleVariants({
+  [BadgeSize.small]: {
+    padding: '4px 8px',
+  },
+  [BadgeSize.medium]: {
+    padding: '8px 16px',
+  },
+  [BadgeSize.large]: {
+    padding: '12px 24px',
+  },
+});
+
+// Font size by badge size
+export const fontSize = styleVariants({
+  [BadgeSize.small]: {
+    fontSize: fontSizeToken[12],
+  },
+  [BadgeSize.medium]: {
+    fontSize: fontSizeToken[14],
+  },
+  [BadgeSize.large]: {
+    fontSize: fontSizeToken[18],
+  },
+});
+
+// Variant styles
+export const variant = styleVariants({
+  [BadgeVariant.filled]: {
+    backgroundColor: '#2D3748',
+    border: 'none',
+  },
+  [BadgeVariant.outline]: {
+    backgroundColor: 'transparent',
+    border: '2px solid #2D3748',
+  },
+  [BadgeVariant.weak]: {
+    backgroundColor: '#EDF2F7',
+    border: 'none',
+  },
+});
+
+// Text style
+export const text = style({
+  color: '#00FFFF',
+  fontWeight: 600,
+});

--- a/packages/badge/src/Badge.module.css
+++ b/packages/badge/src/Badge.module.css
@@ -1,6 +1,0 @@
-.root {
-  background-color: var(--background-color);
-  border: var(--border);
-  border-radius: 8px;
-  padding: var(--padding);
-}

--- a/packages/badge/src/Badge.stories.tsx
+++ b/packages/badge/src/Badge.stories.tsx
@@ -1,11 +1,26 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Badge } from './Badge';
+import { Badge, type BadgeSize, type BadgeVariant } from './Badge';
+import { BadgeSize as BadgeSizeEnum, BadgeVariant as BadgeVariantEnum } from './Badge.css';
 
 const meta = {
   title: 'Components/Badge',
   component: Badge,
   parameters: {
     layout: 'centered',
+  },
+  argTypes: {
+    size: {
+      control: 'select',
+      options: Object.keys(BadgeSizeEnum),
+      description: 'Size of the badge',
+      defaultValue: 'medium',
+    },
+    variant: {
+      control: 'select',
+      options: Object.keys(BadgeVariantEnum),
+      description: 'Visual style of the badge',
+      defaultValue: 'filled',
+    },
   },
 } satisfies Meta<typeof Badge>;
 export default meta;
@@ -15,5 +30,31 @@ type Story = StoryObj<typeof meta>;
 export const Basic: Story = {
   args: {
     children: '사이프',
+    size: 'medium',
+    variant: 'filled',
   },
+};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div style={{ display: 'flex', gap: '10px', alignItems: 'center' }}>
+      {Object.keys(BadgeSizeEnum).map((size) => (
+        <Badge key={size} {...args} size={size as BadgeSize}>
+          {size}
+        </Badge>
+      ))}
+    </div>
+  ),
+};
+
+export const Variants: Story = {
+  render: (args) => (
+    <div style={{ display: 'flex', gap: '10px', alignItems: 'center' }}>
+      {Object.keys(BadgeVariantEnum).map((variant) => (
+        <Badge key={variant} {...args} variant={variant as BadgeVariant}>
+          {variant}
+        </Badge>
+      ))}
+    </div>
+  ),
 };

--- a/packages/badge/src/Badge.test.tsx
+++ b/packages/badge/src/Badge.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { Badge } from './Badge';
+import { color as colorToken } from '@sipe-team/tokens';
 
 test('children으로 입력한 텍스트를 표시한다.', () => {
   render(<Badge>테스트</Badge>);
@@ -14,10 +15,10 @@ test('모서리가 8px radius 형태이다.', () => {
   expect(screen.getByRole('status')).toHaveStyle({ borderRadius: '8px' });
 });
 
-test('글꼴 색상은 teal(#00FFFF)이다.', () => {
+test(`글꼴 색상은 cyan300(${colorToken.cyan300})이다.`, () => {
   render(<Badge>테스트</Badge>);
 
-  expect(screen.getByText('테스트')).toHaveStyle({ color: '#00FFFF' });
+  expect(screen.getByText('테스트')).toHaveStyle({ color: colorToken.cyan300 });
 });
 
 test('글꼴 두께는 semiBold(600)이다.', () => {
@@ -26,28 +27,28 @@ test('글꼴 두께는 semiBold(600)이다.', () => {
   expect(screen.getByText('테스트')).toHaveStyle({ fontWeight: 600 });
 });
 
-test('variant를 주입하지 않으면 filled(배경색 #2D3748)를 기본 형태로 설정한다.', () => {
+test(`variant를 주입하지 않으면 filled(${colorToken.cyan900})를 기본 형태로 설정한다.`, () => {
   render(<Badge>테스트</Badge>);
 
   expect(screen.getByRole('status')).toHaveStyle({
-    backgroundColor: '#2D3748',
+    backgroundColor: colorToken.cyan900,
   });
 });
 
-test('variant가 weak인 경우 배경색 #EDF2F7로 형태를 적용한다.', () => {
+test('variant가 weak인 경우 배경색 gray200로 형태를 적용한다.', () => {
   render(<Badge variant="weak">테스트</Badge>);
 
   expect(screen.getByRole('status')).toHaveStyle({
-    backgroundColor: '#EDF2F7',
+    backgroundColor: '#e4e4e7',
   });
 });
 
-test('variant가 outline인 경우 배경색은 투명, 테두리는 2px 두께의 #2D3748 색상 형태를 적용한다.', () => {
+test('variant가 outline인 경우 배경색은 투명, 테두리는 2px 두께의 cyan900 색상 형태를 적용한다.', () => {
   render(<Badge variant="outline">테스트</Badge>);
 
   expect(screen.getByRole('status')).toHaveStyle({
     backgroundColor: 'transparent',
-    border: '2px solid #2D3748',
+    border: `2px solid ${colorToken.cyan900}`,
   });
 });
 

--- a/packages/badge/src/Badge.tsx
+++ b/packages/badge/src/Badge.tsx
@@ -1,16 +1,10 @@
 import { Typography } from '@sipe-team/typography';
 import { clsx as cx } from 'clsx';
-import {
-  type CSSProperties,
-  type ComponentProps,
-  type ForwardedRef,
-  forwardRef,
-} from 'react';
-import styles from './Badge.module.css';
+import { type ComponentProps, type ForwardedRef, forwardRef } from 'react';
+import * as styles from './Badge.css';
 
-type BadgeSize = 'small' | 'medium' | 'large';
-
-type BadgeVariant = 'filled' | 'outline' | 'weak';
+export type BadgeSize = keyof typeof styles.BadgeSize;
+export type BadgeVariant = keyof typeof styles.BadgeVariant;
 
 export interface BadgeProps extends ComponentProps<'div'> {
   size?: BadgeSize;
@@ -18,71 +12,24 @@ export interface BadgeProps extends ComponentProps<'div'> {
 }
 
 export const Badge = forwardRef(function Badge(
-  {
-    className,
-    children,
-    size = 'medium',
-    style: _style,
-    variant = 'filled',
-    ...props
-  }: BadgeProps,
+  { className, children, size = 'medium', variant = 'filled', ...props }: BadgeProps,
   ref: ForwardedRef<HTMLDivElement>,
 ) {
-  const backgroundColor = getBackgroundColor(variant);
-  const border = variant === 'outline' ? '2px solid #2D3748' : undefined;
-  const padding = getPadding(size);
-  const style = {
-    ..._style,
-    '--background-color': backgroundColor,
-    '--border': border,
-    '--padding': padding,
-  } as CSSProperties;
-
-  const fontSize = getFontSize(size);
-
   return (
     <div
-      className={cx(styles.root, className)}
+      className={cx(styles.root, styles.size[size], styles.variant[variant], className)}
       ref={ref}
       role="status"
-      style={style}
       {...props}
     >
-      <Typography
-        asChild={true}
-        color="#00FFFF"
-        size={fontSize}
-        weight="semiBold"
-      >
+      <Typography asChild={true} className={styles.text} size={getTypographySize(size)} weight="semiBold">
         <span>{children}</span>
       </Typography>
     </div>
   );
 });
 
-function getBackgroundColor(variant: BadgeVariant) {
-  switch (variant) {
-    case 'weak':
-      return '#EDF2F7';
-    case 'outline':
-      return 'transparent';
-    default:
-      return '#2D3748';
-  }
-}
-
-function getPadding(size: BadgeSize) {
-  switch (size) {
-    case 'small':
-      return '4px 8px';
-    case 'large':
-      return '12px 24px';
-    default:
-      return '8px 16px';
-  }
-}
-
-function getFontSize(size: BadgeSize) {
+function getTypographySize(size: BadgeSize): 12 | 14 | 18 {
   switch (size) {
     case 'small':
       return 12;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,10 @@ catalogs:
 importers:
 
   .:
+    dependencies:
+      '@vanilla-extract/css':
+        specifier: ^1.17.1
+        version: 1.17.1
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.4
@@ -403,6 +407,9 @@ importers:
 
   packages/badge:
     dependencies:
+      '@sipe-team/tokens':
+        specifier: workspace:*
+        version: link:../tokens
       '@sipe-team/typography':
         specifier: workspace:*
         version: link:../typography
@@ -440,6 +447,9 @@ importers:
       '@types/react':
         specifier: ^18.3.12
         version: 18.3.13
+      '@vanilla-extract/css':
+        specifier: 'catalog:'
+        version: 1.17.1
       happy-dom:
         specifier: 'catalog:'
         version: 15.11.7
@@ -9118,7 +9128,7 @@ packages:
     engines: {node: '>= 4'}
 
   utils-merge@1.0.1:
-    resolution: {integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=}
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
   uuid@8.3.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,10 +70,6 @@ catalogs:
 importers:
 
   .:
-    dependencies:
-      '@vanilla-extract/css':
-        specifier: ^1.17.1
-        version: 1.17.1
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.4


### PR DESCRIPTION
## Changes

- Migrate Badge Component from module css to vanilla extract
- Enhance badge storybook.

> seems like theme feature is needed

## Visuals
<!-- If there are any screenshots or visual materials, please attach them. -->

## Checklist
- [ ] Have you written the functional specifications?
- [ ] Have you written the test code?

## Additional Discussion Points
<!-- If there are any additional points to be aware of, please specify them. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Vanilla Extract 기반의 CSS-in-TypeScript 스타일링이 Avatar와 Badge 컴포넌트에 도입되었습니다.
	- Badge 컴포넌트에 다양한 크기와 스타일(variant) 옵션이 추가되었습니다.
- **Refactor**
	- Avatar 및 Badge 컴포넌트가 기존 CSS 모듈과 인라인 스타일에서 Vanilla Extract 스타일 시스템으로 전환되었습니다.
	- 타입 정의 및 props 구조가 더욱 명확하고 일관성 있게 개선되었습니다.
- **Chores**
	- 빌드 및 테스트 설정에 Vanilla Extract 관련 플러그인과 Vite, Esbuild 통합이 추가되었습니다.
	- 중복된 설정이 공통 파일로 통합되어 유지보수가 용이해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->