### PR TITLE
fix(workflow): update storybook deploy path

### DIFF
--- a/.github/workflows/storybook-deploy.yaml
+++ b/.github/workflows/storybook-deploy.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - '**/*.stories.@(js|jsx|ts|tsx)'
+      - 'packages/**/src/**/*.stories.@(js|jsx|ts|tsx)'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Changes

기존 스토리북 배포 관련 Trigger Path가 잘못되어 있는거 같아서 수정했습니다.

## Visuals
<!-- If there are any screenshots or visual materials, please attach them. -->

## Checklist
- [ ] Have you written the functional specifications?
- [ ] Have you written the test code?

## Additional Discussion Points
<!-- If there are any additional points to be aware of, please specify them. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Storybook 배포 워크플로우가 이제 `packages` 디렉터리 내 `src` 폴더에 위치한 스토리 파일 변경 시에만 실행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->