### PR TITLE
refactor(theme): Use assignInlineVars for theme variable binding

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -39,6 +39,7 @@
     "vitest": "catalog:"
   },
   "dependencies": {
+    "@vanilla-extract/dynamic": "^2.1.2",
     "@sipe-team/tokens": "workspace:*"
   },
   "publishConfig": {

--- a/packages/theme/src/ThemeProvider.tsx
+++ b/packages/theme/src/ThemeProvider.tsx
@@ -1,7 +1,9 @@
 import type React from 'react';
-import { createContext, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { createContext, useContext, useMemo, useState } from 'react';
 
 import { type ThemeColor, themeColor, vars } from '@sipe-team/tokens';
+
+import { assignInlineVars } from '@vanilla-extract/dynamic';
 
 interface ThemeContextType {
   theme: ThemeColor;
@@ -25,20 +27,6 @@ interface ThemeProviderProps {
 
 export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children, theme: initialTheme = themeColor['4th'] }) => {
   const [theme, setTheme] = useState<ThemeColor>(initialTheme);
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    setTheme(initialTheme);
-  }, [initialTheme]);
-
-  useEffect(() => {
-    if (containerRef.current) {
-      // Apply theme colors as CSS variables
-      Object.entries(theme).forEach(([key, value]) => {
-        containerRef.current?.style.setProperty(`--side-color-${key}`, value);
-      });
-    }
-  }, [theme]);
 
   const contextValue = useMemo(
     () => ({
@@ -48,11 +36,11 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children, theme: i
     [theme],
   );
 
+  const themeVars = assignInlineVars(vars.color, theme);
+
   return (
     <ThemeContext.Provider value={contextValue}>
-      <div ref={containerRef} style={{ display: 'contents' }}>
-        {children}
-      </div>
+      <div style={{ ...themeVars, display: 'contents' }}>{children}</div>
     </ThemeContext.Provider>
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1299,6 +1299,9 @@ importers:
       '@sipe-team/tokens':
         specifier: workspace:*
         version: link:../tokens
+      '@vanilla-extract/dynamic':
+        specifier: ^2.1.2
+        version: 2.1.5
     devDependencies:
       '@storybook/addon-essentials':
         specifier: 'catalog:'


### PR DESCRIPTION
## Changes

ThemeProvider에서DOM 조작 방식을 선언형 contract 시스템으로 변경했습니다.

`@vanilla-extract/dynamic`의 `assignInlineVars`를 사용하여 Vanilla Extract의 contract 시스템을 그대로 쓸 수 있게됩니다.

- 수동 CSS 변수명(`--side-color-primary`)이 contract 정의와 일치하지 않음

```tsx
// tokens/src/theme/contract.ts - Contract 정의
export const vars = createGlobalThemeContract({
  color: {
    primary: 'color-primary',
    background: 'color-background'
  }
}, (value) => `side-${value}`);
// 실제 생성되는 CSS 변수: --side-color-primary, --side-color-background
```

```tsx
// theme/src/ThemeProvider.tsx - 기존 방식 (문제)
useEffect(() => {
  if (containerRef.current) {
    Object.entries(theme).forEach(([key, value]) => {
      // 여기서 설정하는 변수명과 contract가 다름
      containerRef.current?.style.setProperty(`--side-color-${key}`, value);
      //                                        ^^^^^^^^^^^^^^^^
      //                                        예: --side-color-primary
    });
  }
}, [theme]);
```

```tsx
// button/src/Button.css.ts - CSS에서 사용 (문제)
[ButtonVariant.filled]: {
  // Contract 참조와 하드코딩된 변수명이 혼재
  backgroundColor: vars.color.primary,           // ← Contract 참조
  color: `var(--side-color-background, black)`, // ← 하드코딩된 변수명
  //           ^^^^^^^^^^^^^^^^^^^^^^
  //           수동으로 작성한 변수명이 contract와 일치한다는 보장 없음
}
```

---

```tsx
// theme/src/ThemeProvider.tsx - assignInlineVars 사용
const themeVars = assignInlineVars(vars.color, theme);
// Contract와 theme 값을 자동으로 매핑
```