### PR TITLE
fix(changeset): remove invalid package name from ignore list

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@sipe-team/package-name"]
+  "ignore": []
 }


### PR DESCRIPTION
## Summary
- changeset config의 `ignore`에 워크스페이스에 존재하지 않는 `@sipe-team/package-name` 플레이스홀더가 있어 `changeset publish` 시 ValidationError 발생
- `ignore` 배열을 비워서 해결

- https://github.com/sipe-team/side/actions/runs/24239559057/job/70770501186

## Test plan
- [x] CI 통과 확인
- [ ] release workflow에서 `changeset publish` 정상 동작 확인