### PR TITLE
chore: standardize catalog deps and chip package

### DIFF
--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -23,11 +23,11 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
-    "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-slot": "catalog:",
     "@sipe-team/tokens": "workspace:*",
     "@vanilla-extract/css": "catalog:",
-    "@vanilla-extract/recipes": "^0.5.5",
-    "clsx": "^2.1.0",
+    "@vanilla-extract/recipes": "catalog:",
+    "clsx": "catalog:",
     "@sipe-team/icon": "workspace:*"
   },
   "devDependencies": {

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -23,13 +23,13 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
-    "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-slot": "catalog:",
     "@sipe-team/typography": "workspace:^",
     "@sipe-team/tokens": "workspace:*",
-    "clsx": "^2.1.1"
+    "clsx": "catalog:"
   },
   "devDependencies": {
-    "@faker-js/faker": "^9.2.0",
+    "@faker-js/faker": "catalog:",
     "@storybook/addon-essentials": "catalog:",
     "@storybook/addon-interactions": "catalog:",
     "@storybook/addon-links": "catalog:",
@@ -38,8 +38,8 @@
     "@storybook/react-vite": "catalog:",
     "@storybook/test": "catalog:",
     "@types/react": "catalog:react",
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
     "@vanilla-extract/css": "catalog:",
     "happy-dom": "catalog:",
     "react": "catalog:react",

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@sipe-team/tokens": "workspace:*",
     "@sipe-team/typography": "workspace:*",
-    "clsx": "^2.1.1"
+    "clsx": "catalog:"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "catalog:",
@@ -35,8 +35,8 @@
     "@storybook/react": "catalog:",
     "@storybook/react-vite": "catalog:",
     "@storybook/test": "catalog:",
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
     "@types/react": "catalog:react",
     "@vanilla-extract/css": "catalog:",
     "happy-dom": "catalog:",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -23,11 +23,11 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
-    "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-slot": "catalog:",
     "@sipe-team/tokens": "workspace:*",
     "@sipe-team/typography": "workspace:*",
-    "@vanilla-extract/recipes": "^0.5.5",
-    "clsx": "^2.1.1"
+    "@vanilla-extract/recipes": "catalog:",
+    "clsx": "catalog:"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "catalog:",
@@ -37,8 +37,8 @@
     "@storybook/react": "catalog:",
     "@storybook/react-vite": "catalog:",
     "@storybook/test": "catalog:",
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
     "@types/react": "catalog:react",
     "@vanilla-extract/css": "catalog:",
     "happy-dom": "catalog:",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -23,9 +23,9 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
-    "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-slot": "catalog:",
     "@sipe-team/tokens": "workspace:*",
-    "clsx": "^2.1.1"
+    "clsx": "catalog:"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "catalog:",
@@ -35,11 +35,11 @@
     "@storybook/react": "catalog:",
     "@storybook/react-vite": "catalog:",
     "@storybook/test": "catalog:",
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
     "@types/react": "catalog:react",
     "@vanilla-extract/css": "catalog:",
-    "@vanilla-extract/recipes": "^0.5.5",
+    "@vanilla-extract/recipes": "catalog:",
     "happy-dom": "catalog:",
     "react": "catalog:react",
     "react-dom": "catalog:react",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -24,8 +24,8 @@
   },
   "dependencies": {
     "@sipe-team/tokens": "workspace:*",
-    "clsx": "^2.1.1",
-    "@vanilla-extract/recipes": "^0.5.5"
+    "clsx": "catalog:",
+    "@vanilla-extract/recipes": "catalog:"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "catalog:",

--- a/packages/chip/package.json
+++ b/packages/chip/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@side/chip",
+  "name": "@sipe-team/chip",
   "version": "0.0.1",
   "description": "Chip component for SIDE design system",
   "main": "./dist/index.js",
@@ -25,22 +25,22 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@radix-ui/react-slot": "^1.0.2",
-    "@vanilla-extract/css": "^1.14.0",
-    "@vanilla-extract/recipes": "^0.5.1",
-    "clsx": "^2.0.0"
+    "@radix-ui/react-slot": "catalog:",
+    "@vanilla-extract/css": "catalog:",
+    "@vanilla-extract/recipes": "catalog:",
+    "clsx": "catalog:"
   },
   "devDependencies": {
     "@sipe-team/tokens": "workspace:*",
     "@testing-library/jest-dom": "catalog:",
     "@testing-library/react": "catalog:",
     "@testing-library/user-event": "catalog:",
-    "@types/react": "^18.2.0",
+    "@types/react": "catalog:react",
     "jsdom": "^26.1.0",
-    "react": "^18.2.0",
-    "tsup": "^8.0.0",
-    "typescript": "^5.0.0",
-    "vitest": "^1.0.0"
+    "react": "catalog:react",
+    "tsup": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "peerDependencies": {
     "react": ">=18.0.0"

--- a/packages/chip/tsup.config.ts
+++ b/packages/chip/tsup.config.ts
@@ -1,9 +1,8 @@
 import { defineConfig } from 'tsup';
 
+import defaultConfig from '../../tsup.config';
+
 export default defineConfig({
-  entry: ['src/index.ts'],
-  format: ['cjs', 'esm'],
-  dts: true,
-  clean: true,
+  ...defaultConfig,
   external: ['react', '@radix-ui/react-slot', 'clsx'],
 });

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -23,7 +23,7 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
-    "clsx": "^2.1.1",
+    "clsx": "catalog:",
     "@sipe-team/tokens": "workspace:*"
   },
   "devDependencies": {
@@ -35,8 +35,8 @@
     "@storybook/react": "catalog:",
     "@storybook/react-vite": "catalog:",
     "@storybook/test": "catalog:",
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
     "@types/react": "catalog:react",
     "@vanilla-extract/css": "catalog:",
     "happy-dom": "catalog:",

--- a/packages/flex/package.json
+++ b/packages/flex/package.json
@@ -23,11 +23,11 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
-    "@radix-ui/react-slot": "^1.1.0",
-    "clsx": "^2.1.1"
+    "@radix-ui/react-slot": "catalog:",
+    "clsx": "catalog:"
   },
   "devDependencies": {
-    "@faker-js/faker": "^9.2.0",
+    "@faker-js/faker": "catalog:",
     "@storybook/addon-essentials": "catalog:",
     "@storybook/addon-interactions": "catalog:",
     "@storybook/addon-links": "catalog:",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -23,11 +23,11 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
-    "@radix-ui/react-slot": "^1.1.0",
-    "clsx": "^2.1.1"
+    "@radix-ui/react-slot": "catalog:",
+    "clsx": "catalog:"
   },
   "devDependencies": {
-    "@faker-js/faker": "^9.2.0",
+    "@faker-js/faker": "catalog:",
     "@storybook/addon-essentials": "catalog:",
     "@storybook/addon-interactions": "catalog:",
     "@storybook/addon-links": "catalog:",

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -23,10 +23,10 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
-    "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-slot": "catalog:",
     "@sipe-team/tokens": "workspace:*",
-    "@vanilla-extract/recipes": "^0.5.5",
-    "clsx": "^2.1.1"
+    "@vanilla-extract/recipes": "catalog:",
+    "clsx": "catalog:"
   },
   "devDependencies": {
     "@vanilla-extract/css": "catalog:",
@@ -37,9 +37,9 @@
     "@storybook/react": "catalog:",
     "@storybook/react-vite": "catalog:",
     "@storybook/test": "catalog:",
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
-    "@testing-library/user-event": "^14.5.2",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
+    "@testing-library/user-event": "catalog:",
     "@types/react": "catalog:react",
     "happy-dom": "catalog:",
     "react": "catalog:react",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -25,8 +25,8 @@
   "dependencies": {
     "@sipe-team/tokens": "workspace:*",
     "@sipe-team/typography": "workspace:*",
-    "@vanilla-extract/recipes": "^0.5.5",
-    "clsx": "^2.1.1"
+    "@vanilla-extract/recipes": "catalog:",
+    "clsx": "catalog:"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "catalog:",
@@ -36,10 +36,10 @@
     "@storybook/react": "catalog:",
     "@storybook/react-vite": "catalog:",
     "@storybook/test": "catalog:",
-    "@testing-library/dom": "^10.4.0",
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
-    "@testing-library/user-event": "^14.5.2",
+    "@testing-library/dom": "catalog:",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
+    "@testing-library/user-event": "catalog:",
     "@types/react": "catalog:react",
     "@types/react-dom": "catalog:react",
     "@vanilla-extract/css": "catalog:",

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -24,12 +24,12 @@
   },
   "dependencies": {
     "@sipe-team/tokens": "workspace:*",
-    "@radix-ui/react-slot": "^1.1.0",
-    "@vanilla-extract/recipes": "^0.5.5",
-    "clsx": "^2.1.1"
+    "@radix-ui/react-slot": "catalog:",
+    "@vanilla-extract/recipes": "catalog:",
+    "clsx": "catalog:"
   },
   "devDependencies": {
-    "@faker-js/faker": "^9.2.0",
+    "@faker-js/faker": "catalog:",
     "@storybook/addon-essentials": "catalog:",
     "@storybook/addon-interactions": "catalog:",
     "@storybook/addon-links": "catalog:",
@@ -37,8 +37,8 @@
     "@storybook/react": "catalog:",
     "@storybook/react-vite": "catalog:",
     "@storybook/test": "catalog:",
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
     "@vanilla-extract/css": "catalog:",
     "@types/react": "catalog:react",
     "happy-dom": "catalog:",

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -25,11 +25,11 @@
   "dependencies": {
     "@radix-ui/react-use-controllable-state": "^1.2.2",
     "@sipe-team/tokens": "workspace:^",
-    "@vanilla-extract/recipes": "^0.5.5",
-    "clsx": "^2.1.1"
+    "@vanilla-extract/recipes": "catalog:",
+    "clsx": "catalog:"
   },
   "devDependencies": {
-    "@faker-js/faker": "^9.2.0",
+    "@faker-js/faker": "catalog:",
     "@storybook/addon-essentials": "catalog:",
     "@storybook/addon-interactions": "catalog:",
     "@storybook/addon-links": "catalog:",
@@ -37,9 +37,9 @@
     "@storybook/react": "catalog:",
     "@storybook/react-vite": "catalog:",
     "@storybook/test": "catalog:",
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
-    "@testing-library/user-event": "^14.5.2",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
+    "@testing-library/user-event": "catalog:",
     "@types/react": "catalog:react",
     "@vanilla-extract/css": "catalog:",
     "@vanilla-extract/vite-plugin": "catalog:",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -41,7 +41,7 @@
     "vitest": "catalog:"
   },
   "dependencies": {
-    "@vanilla-extract/dynamic": "^2.1.2",
+    "@vanilla-extract/dynamic": "catalog:",
     "@sipe-team/tokens": "workspace:*"
   },
   "publishConfig": {

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -23,11 +23,11 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
-    "@radix-ui/react-slot": "^1.1.0",
-    "clsx": "^2.1.1"
+    "@radix-ui/react-slot": "catalog:",
+    "clsx": "catalog:"
   },
   "devDependencies": {
-    "@faker-js/faker": "^9.2.0",
+    "@faker-js/faker": "catalog:",
     "@storybook/addon-essentials": "catalog:",
     "@storybook/addon-interactions": "catalog:",
     "@storybook/addon-links": "catalog:",
@@ -35,9 +35,9 @@
     "@storybook/react": "catalog:",
     "@storybook/react-vite": "catalog:",
     "@storybook/test": "catalog:",
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
-    "@testing-library/user-event": "^14.5.2",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
+    "@testing-library/user-event": "catalog:",
     "@types/react": "catalog:react",
     "@types/react-dom": "catalog:react",
     "@vanilla-extract/css": "catalog:",

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -23,13 +23,13 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
-    "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-slot": "catalog:",
     "@sipe-team/tokens": "workspace:^",
-    "@vanilla-extract/dynamic": "^2.1.3",
-    "clsx": "^2.1.1"
+    "@vanilla-extract/dynamic": "catalog:",
+    "clsx": "catalog:"
   },
   "devDependencies": {
-    "@faker-js/faker": "^9.2.0",
+    "@faker-js/faker": "catalog:",
     "@storybook/addon-essentials": "catalog:",
     "@storybook/addon-interactions": "catalog:",
     "@storybook/addon-links": "catalog:",
@@ -37,8 +37,8 @@
     "@storybook/react": "catalog:",
     "@storybook/react-vite": "catalog:",
     "@storybook/test": "catalog:",
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
     "@types/react": "catalog:react",
     "@vanilla-extract/css": "catalog:",
     "happy-dom": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,12 @@ settings:
 
 catalogs:
   default:
+    '@faker-js/faker':
+      specifier: ^9.2.0
+      version: 9.2.0
+    '@radix-ui/react-slot':
+      specifier: ^1.1.0
+      version: 1.1.0
     '@storybook/addon-essentials':
       specifier: ^8.4.5
       version: 8.4.6
@@ -27,6 +33,9 @@ catalogs:
     '@storybook/test':
       specifier: ^8.4.5
       version: 8.4.6
+    '@testing-library/dom':
+      specifier: ^10.4.0
+      version: 10.4.0
     '@testing-library/jest-dom':
       specifier: ^6.6.3
       version: 6.6.3
@@ -39,15 +48,24 @@ catalogs:
     '@vanilla-extract/css':
       specifier: ^1.14.1
       version: 1.20.1
+    '@vanilla-extract/dynamic':
+      specifier: ^2.1.3
+      version: 2.1.5
     '@vanilla-extract/esbuild-plugin':
       specifier: ^2.3.15
       version: 2.3.22
+    '@vanilla-extract/recipes':
+      specifier: ^0.5.5
+      version: 0.5.7
     '@vanilla-extract/vite-plugin':
       specifier: ^5.0.1
       version: 5.2.2
     '@vitest/coverage-v8':
       specifier: ^2.1.8
       version: 2.1.8
+    clsx:
+      specifier: ^2.1.1
+      version: 2.1.1
     happy-dom:
       specifier: ^15.7.4
       version: 15.11.7
@@ -205,7 +223,7 @@ importers:
   packages/accordion:
     dependencies:
       '@radix-ui/react-slot':
-        specifier: ^1.1.0
+        specifier: 'catalog:'
         version: 1.1.0(@types/react@18.3.13)(react@18.3.1)
       '@sipe-team/icon':
         specifier: workspace:*
@@ -217,10 +235,10 @@ importers:
         specifier: 'catalog:'
         version: 1.20.1
       '@vanilla-extract/recipes':
-        specifier: ^0.5.5
+        specifier: 'catalog:'
         version: 0.5.7(@vanilla-extract/css@1.20.1)
       clsx:
-        specifier: ^2.1.0
+        specifier: 'catalog:'
         version: 2.1.1
     devDependencies:
       '@sipe-team/typography':
@@ -243,7 +261,7 @@ importers:
         version: 8.4.6(@storybook/test@8.4.6(storybook@8.5.0(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.5.0(prettier@2.8.8))(typescript@5.6.3)
       '@storybook/react-vite':
         specifier: 'catalog:'
-        version: 8.4.6(@storybook/test@8.4.6(storybook@8.5.0(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.1)(storybook@8.5.0(prettier@2.8.8))(typescript@5.6.3)(vite@5.4.11(@types/node@22.10.1)(lightningcss@1.32.0)(terser@5.37.0))
+        version: 8.4.6(@storybook/test@8.4.6(storybook@8.5.0(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.1)(storybook@8.5.0(prettier@2.8.8))(typescript@5.6.3)(vite@8.0.8(@types/node@22.10.1)(esbuild@0.27.7)(jiti@2.4.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.6.1))
       '@storybook/test':
         specifier: 'catalog:'
         version: 8.4.6(storybook@8.5.0(prettier@2.8.8))
@@ -281,7 +299,7 @@ importers:
   packages/avatar:
     dependencies:
       '@radix-ui/react-slot':
-        specifier: ^1.1.0
+        specifier: 'catalog:'
         version: 1.1.0(@types/react@18.3.13)(react@18.3.1)
       '@sipe-team/tokens':
         specifier: workspace:*
@@ -290,11 +308,11 @@ importers:
         specifier: workspace:^
         version: link:../typography
       clsx:
-        specifier: ^2.1.1
+        specifier: 'catalog:'
         version: 2.1.1
     devDependencies:
       '@faker-js/faker':
-        specifier: ^9.2.0
+        specifier: 'catalog:'
         version: 9.2.0
       '@storybook/addon-essentials':
         specifier: 'catalog:'
@@ -318,10 +336,10 @@ importers:
         specifier: 'catalog:'
         version: 8.4.6(storybook@8.5.0(prettier@2.8.8))
       '@testing-library/jest-dom':
-        specifier: ^6.6.3
+        specifier: 'catalog:'
         version: 6.6.3
       '@testing-library/react':
-        specifier: ^16.0.1
+        specifier: 'catalog:'
         version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: catalog:react
@@ -360,7 +378,7 @@ importers:
         specifier: workspace:*
         version: link:../typography
       clsx:
-        specifier: ^2.1.1
+        specifier: 'catalog:'
         version: 2.1.1
     devDependencies:
       '@storybook/addon-essentials':
@@ -385,10 +403,10 @@ importers:
         specifier: 'catalog:'
         version: 8.4.6(storybook@8.5.0(prettier@2.8.8))
       '@testing-library/jest-dom':
-        specifier: ^6.6.3
+        specifier: 'catalog:'
         version: 6.6.3
       '@testing-library/react':
-        specifier: ^16.0.1
+        specifier: 'catalog:'
         version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: catalog:react
@@ -424,7 +442,7 @@ importers:
   packages/button:
     dependencies:
       '@radix-ui/react-slot':
-        specifier: ^1.1.0
+        specifier: 'catalog:'
         version: 1.1.0(@types/react@18.3.13)(react@18.3.1)
       '@sipe-team/tokens':
         specifier: workspace:*
@@ -433,10 +451,10 @@ importers:
         specifier: workspace:*
         version: link:../typography
       '@vanilla-extract/recipes':
-        specifier: ^0.5.5
+        specifier: 'catalog:'
         version: 0.5.7(@vanilla-extract/css@1.20.1)
       clsx:
-        specifier: ^2.1.1
+        specifier: 'catalog:'
         version: 2.1.1
     devDependencies:
       '@storybook/addon-essentials':
@@ -461,10 +479,10 @@ importers:
         specifier: 'catalog:'
         version: 8.4.6(storybook@8.5.0(prettier@2.8.8))
       '@testing-library/jest-dom':
-        specifier: ^6.6.3
+        specifier: 'catalog:'
         version: 6.6.3
       '@testing-library/react':
-        specifier: ^16.0.1
+        specifier: 'catalog:'
         version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: catalog:react
@@ -500,13 +518,13 @@ importers:
   packages/card:
     dependencies:
       '@radix-ui/react-slot':
-        specifier: ^1.1.0
+        specifier: 'catalog:'
         version: 1.1.0(@types/react@18.3.13)(react@18.3.1)
       '@sipe-team/tokens':
         specifier: workspace:*
         version: link:../tokens
       clsx:
-        specifier: ^2.1.1
+        specifier: 'catalog:'
         version: 2.1.1
     devDependencies:
       '@storybook/addon-essentials':
@@ -531,10 +549,10 @@ importers:
         specifier: 'catalog:'
         version: 8.4.6(storybook@8.5.0(prettier@2.8.8))
       '@testing-library/jest-dom':
-        specifier: ^6.6.3
+        specifier: 'catalog:'
         version: 6.6.3
       '@testing-library/react':
-        specifier: ^16.0.1
+        specifier: 'catalog:'
         version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: catalog:react
@@ -543,7 +561,7 @@ importers:
         specifier: 'catalog:'
         version: 1.20.1
       '@vanilla-extract/recipes':
-        specifier: ^0.5.5
+        specifier: 'catalog:'
         version: 0.5.7(@vanilla-extract/css@1.20.1)
       happy-dom:
         specifier: 'catalog:'
@@ -576,10 +594,10 @@ importers:
         specifier: workspace:*
         version: link:../tokens
       '@vanilla-extract/recipes':
-        specifier: ^0.5.5
+        specifier: 'catalog:'
         version: 0.5.7(@vanilla-extract/css@1.20.1)
       clsx:
-        specifier: ^2.1.1
+        specifier: 'catalog:'
         version: 2.1.1
     devDependencies:
       '@storybook/addon-essentials':
@@ -692,7 +710,7 @@ importers:
         specifier: workspace:*
         version: link:../tokens
       clsx:
-        specifier: ^2.1.1
+        specifier: 'catalog:'
         version: 2.1.1
     devDependencies:
       '@sipe-team/typography':
@@ -720,10 +738,10 @@ importers:
         specifier: 'catalog:'
         version: 8.4.6(storybook@8.5.0(prettier@2.8.8))
       '@testing-library/jest-dom':
-        specifier: ^6.6.3
+        specifier: 'catalog:'
         version: 6.6.3
       '@testing-library/react':
-        specifier: ^16.0.1
+        specifier: 'catalog:'
         version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: catalog:react
@@ -756,14 +774,14 @@ importers:
   packages/flex:
     dependencies:
       '@radix-ui/react-slot':
-        specifier: ^1.1.0
+        specifier: 'catalog:'
         version: 1.1.0(@types/react@18.3.13)(react@18.3.1)
       clsx:
-        specifier: ^2.1.1
+        specifier: 'catalog:'
         version: 2.1.1
     devDependencies:
       '@faker-js/faker':
-        specifier: ^9.2.0
+        specifier: 'catalog:'
         version: 9.2.0
       '@storybook/addon-essentials':
         specifier: 'catalog:'
@@ -823,17 +841,17 @@ importers:
   packages/grid:
     dependencies:
       '@radix-ui/react-slot':
-        specifier: ^1.1.0
+        specifier: 'catalog:'
         version: 1.1.0(@types/react@18.3.13)(react@18.3.1)
       clsx:
-        specifier: ^2.1.1
+        specifier: 'catalog:'
         version: 2.1.1
       react-dom:
         specifier: '>= 18'
         version: 18.3.1(react@18.3.1)
     devDependencies:
       '@faker-js/faker':
-        specifier: ^9.2.0
+        specifier: 'catalog:'
         version: 9.2.0
       '@storybook/addon-essentials':
         specifier: 'catalog:'
@@ -947,16 +965,16 @@ importers:
   packages/input:
     dependencies:
       '@radix-ui/react-slot':
-        specifier: ^1.1.0
+        specifier: 'catalog:'
         version: 1.1.0(@types/react@18.3.13)(react@18.3.1)
       '@sipe-team/tokens':
         specifier: workspace:*
         version: link:../tokens
       '@vanilla-extract/recipes':
-        specifier: ^0.5.5
+        specifier: 'catalog:'
         version: 0.5.7(@vanilla-extract/css@1.20.1)
       clsx:
-        specifier: ^2.1.1
+        specifier: 'catalog:'
         version: 2.1.1
     devDependencies:
       '@storybook/addon-essentials':
@@ -981,14 +999,14 @@ importers:
         specifier: 'catalog:'
         version: 8.4.6(storybook@8.5.0(prettier@2.8.8))
       '@testing-library/jest-dom':
-        specifier: ^6.6.3
+        specifier: 'catalog:'
         version: 6.6.3
       '@testing-library/react':
-        specifier: ^16.0.1
+        specifier: 'catalog:'
         version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/user-event':
-        specifier: ^14.5.2
-        version: 14.5.2(@testing-library/dom@10.4.0)
+        specifier: 'catalog:'
+        version: 14.6.1(@testing-library/dom@10.4.0)
       '@types/react':
         specifier: catalog:react
         version: 18.3.13
@@ -1038,10 +1056,10 @@ importers:
         specifier: workspace:*
         version: link:../typography
       '@vanilla-extract/recipes':
-        specifier: ^0.5.5
+        specifier: 'catalog:'
         version: 0.5.7(@vanilla-extract/css@1.20.1)
       clsx:
-        specifier: ^2.1.1
+        specifier: 'catalog:'
         version: 2.1.1
     devDependencies:
       '@storybook/addon-essentials':
@@ -1066,17 +1084,17 @@ importers:
         specifier: 'catalog:'
         version: 8.4.6(storybook@8.5.0(prettier@2.8.8))
       '@testing-library/dom':
-        specifier: ^10.4.0
+        specifier: 'catalog:'
         version: 10.4.0
       '@testing-library/jest-dom':
-        specifier: ^6.6.3
+        specifier: 'catalog:'
         version: 6.6.3
       '@testing-library/react':
-        specifier: ^16.0.1
+        specifier: 'catalog:'
         version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/user-event':
-        specifier: ^14.5.2
-        version: 14.5.2(@testing-library/dom@10.4.0)
+        specifier: 'catalog:'
+        version: 14.6.1(@testing-library/dom@10.4.0)
       '@types/react':
         specifier: catalog:react
         version: 18.3.13
@@ -1194,20 +1212,20 @@ importers:
   packages/skeleton:
     dependencies:
       '@radix-ui/react-slot':
-        specifier: ^1.1.0
+        specifier: 'catalog:'
         version: 1.1.0(@types/react@18.3.13)(react@18.3.1)
       '@sipe-team/tokens':
         specifier: workspace:*
         version: link:../tokens
       '@vanilla-extract/recipes':
-        specifier: ^0.5.5
+        specifier: 'catalog:'
         version: 0.5.7(@vanilla-extract/css@1.20.1)
       clsx:
-        specifier: ^2.1.1
+        specifier: 'catalog:'
         version: 2.1.1
     devDependencies:
       '@faker-js/faker':
-        specifier: ^9.2.0
+        specifier: 'catalog:'
         version: 9.2.0
       '@storybook/addon-essentials':
         specifier: 'catalog:'
@@ -1231,10 +1249,10 @@ importers:
         specifier: 'catalog:'
         version: 8.4.6(storybook@8.5.0(prettier@2.8.8))
       '@testing-library/jest-dom':
-        specifier: ^6.6.3
+        specifier: 'catalog:'
         version: 6.6.3
       '@testing-library/react':
-        specifier: ^16.0.1
+        specifier: 'catalog:'
         version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: catalog:react
@@ -1273,14 +1291,14 @@ importers:
         specifier: workspace:^
         version: link:../tokens
       '@vanilla-extract/recipes':
-        specifier: ^0.5.5
+        specifier: 'catalog:'
         version: 0.5.7(@vanilla-extract/css@1.20.1)
       clsx:
-        specifier: ^2.1.1
+        specifier: 'catalog:'
         version: 2.1.1
     devDependencies:
       '@faker-js/faker':
-        specifier: ^9.2.0
+        specifier: 'catalog:'
         version: 9.2.0
       '@storybook/addon-essentials':
         specifier: 'catalog:'
@@ -1304,14 +1322,14 @@ importers:
         specifier: 'catalog:'
         version: 8.4.6(storybook@8.5.0(prettier@2.8.8))
       '@testing-library/jest-dom':
-        specifier: ^6.6.3
+        specifier: 'catalog:'
         version: 6.6.3
       '@testing-library/react':
-        specifier: ^16.0.1
+        specifier: 'catalog:'
         version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/user-event':
-        specifier: ^14.5.2
-        version: 14.5.2(@testing-library/dom@10.4.0)
+        specifier: 'catalog:'
+        version: 14.6.1(@testing-library/dom@10.4.0)
       '@types/react':
         specifier: catalog:react
         version: 18.3.13
@@ -1349,7 +1367,7 @@ importers:
         specifier: workspace:*
         version: link:../tokens
       '@vanilla-extract/dynamic':
-        specifier: ^2.1.2
+        specifier: 'catalog:'
         version: 2.1.5
     devDependencies:
       '@storybook/addon-essentials':
@@ -1429,14 +1447,14 @@ importers:
   packages/tooltip:
     dependencies:
       '@radix-ui/react-slot':
-        specifier: ^1.1.0
+        specifier: 'catalog:'
         version: 1.1.0(@types/react@18.3.13)(react@18.3.1)
       clsx:
-        specifier: ^2.1.1
+        specifier: 'catalog:'
         version: 2.1.1
     devDependencies:
       '@faker-js/faker':
-        specifier: ^9.2.0
+        specifier: 'catalog:'
         version: 9.2.0
       '@storybook/addon-essentials':
         specifier: 'catalog:'
@@ -1460,14 +1478,14 @@ importers:
         specifier: 'catalog:'
         version: 8.4.6(storybook@8.5.0(prettier@2.8.8))
       '@testing-library/jest-dom':
-        specifier: ^6.6.3
+        specifier: 'catalog:'
         version: 6.6.3
       '@testing-library/react':
-        specifier: ^16.0.1
+        specifier: 'catalog:'
         version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/user-event':
-        specifier: ^14.5.2
-        version: 14.5.2(@testing-library/dom@10.4.0)
+        specifier: 'catalog:'
+        version: 14.6.1(@testing-library/dom@10.4.0)
       '@types/react':
         specifier: catalog:react
         version: 18.3.13
@@ -1502,20 +1520,20 @@ importers:
   packages/typography:
     dependencies:
       '@radix-ui/react-slot':
-        specifier: ^1.1.0
+        specifier: 'catalog:'
         version: 1.1.0(@types/react@18.3.13)(react@18.3.1)
       '@sipe-team/tokens':
         specifier: workspace:^
         version: link:../tokens
       '@vanilla-extract/dynamic':
-        specifier: ^2.1.3
+        specifier: 'catalog:'
         version: 2.1.5
       clsx:
-        specifier: ^2.1.1
+        specifier: 'catalog:'
         version: 2.1.1
     devDependencies:
       '@faker-js/faker':
-        specifier: ^9.2.0
+        specifier: 'catalog:'
         version: 9.2.0
       '@storybook/addon-essentials':
         specifier: 'catalog:'
@@ -1539,10 +1557,10 @@ importers:
         specifier: 'catalog:'
         version: 8.4.6(storybook@8.5.0(prettier@2.8.8))
       '@testing-library/jest-dom':
-        specifier: ^6.6.3
+        specifier: 'catalog:'
         version: 6.6.3
       '@testing-library/react':
-        specifier: ^16.0.1
+        specifier: 'catalog:'
         version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: catalog:react
@@ -14014,6 +14032,11 @@ snapshots:
     dependencies:
       acorn: 8.14.0
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+    optional: true
+
   acorn-walk@8.3.4:
     dependencies:
       acorn: 8.14.0
@@ -15325,7 +15348,7 @@ snapshots:
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.1
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
       ajv: 6.12.6
       chalk: 4.1.2
@@ -15357,8 +15380,8 @@ snapshots:
 
   espree@10.3.0:
     dependencies:
-      acorn: 8.14.0
-      acorn-jsx: 5.3.2(acorn@8.14.0)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 4.2.0
     optional: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -661,16 +661,16 @@ importers:
   packages/chip:
     dependencies:
       '@radix-ui/react-slot':
-        specifier: ^1.0.2
+        specifier: 'catalog:'
         version: 1.1.0(@types/react@18.3.13)(react@18.3.1)
       '@vanilla-extract/css':
-        specifier: ^1.14.0
+        specifier: 'catalog:'
         version: 1.20.1
       '@vanilla-extract/recipes':
-        specifier: ^0.5.1
+        specifier: 'catalog:'
         version: 0.5.7(@vanilla-extract/css@1.20.1)
       clsx:
-        specifier: ^2.0.0
+        specifier: 'catalog:'
         version: 2.1.1
     devDependencies:
       '@sipe-team/tokens':
@@ -686,23 +686,23 @@ importers:
         specifier: 'catalog:'
         version: 14.6.1(@testing-library/dom@10.4.0)
       '@types/react':
-        specifier: ^18.2.0
+        specifier: catalog:react
         version: 18.3.13
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
       react:
-        specifier: ^18.2.0
+        specifier: catalog:react
         version: 18.3.1
       tsup:
-        specifier: ^8.0.0
-        version: 8.3.5(jiti@2.4.1)(postcss@8.5.9)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.1)
+        specifier: 'catalog:'
+        version: 8.5.1(jiti@2.4.1)(postcss@8.5.9)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.1)
       typescript:
-        specifier: ^5.0.0
+        specifier: 'catalog:'
         version: 5.6.3
       vitest:
-        specifier: ^1.0.0
-        version: 1.6.1(@types/node@22.10.1)(happy-dom@15.11.7)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.37.0)
+        specifier: 'catalog:'
+        version: 2.1.8(@types/node@22.10.1)(happy-dom@15.11.7)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.37.0)
 
   packages/divider:
     dependencies:
@@ -4715,9 +4715,6 @@ packages:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@1.6.1':
-    resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
-
   '@vitest/expect@2.0.5':
     resolution: {integrity: sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==}
 
@@ -4741,29 +4738,17 @@ packages:
   '@vitest/pretty-format@2.1.8':
     resolution: {integrity: sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==}
 
-  '@vitest/runner@1.6.1':
-    resolution: {integrity: sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==}
-
   '@vitest/runner@2.1.8':
     resolution: {integrity: sha512-17ub8vQstRnRlIU5k50bG+QOMLHRhYPAna5tw8tYbj+jzjcspnwnwtPtiOlkuKC4+ixDPTuLZiqiWWQ2PSXHVg==}
 
-  '@vitest/snapshot@1.6.1':
-    resolution: {integrity: sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==}
-
   '@vitest/snapshot@2.1.8':
     resolution: {integrity: sha512-20T7xRFbmnkfcmgVEz+z3AU/3b0cEzZOt/zmnvZEctg64/QZbSDJEVm9fLnnlSi74KibmRsO9/Qabi+t0vCRPg==}
-
-  '@vitest/spy@1.6.1':
-    resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
 
   '@vitest/spy@2.0.5':
     resolution: {integrity: sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==}
 
   '@vitest/spy@2.1.8':
     resolution: {integrity: sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==}
-
-  '@vitest/utils@1.6.1':
-    resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
 
   '@vitest/utils@2.0.5':
     resolution: {integrity: sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==}
@@ -4974,9 +4959,6 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
-  assertion-error@1.1.0:
-    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
-
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -5101,12 +5083,6 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
-  bundle-require@5.0.0:
-    resolution: {integrity: sha512-GuziW3fSSmopcx4KRymQEJVbZUfqlCqcq7dvs6TYwKRZiegK/2buMxQTPs6MGlNv50wms1699qYO54R8XfRX4w==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    peerDependencies:
-      esbuild: '>=0.18'
-
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -5177,10 +5153,6 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
-  chai@4.5.0:
-    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
-    engines: {node: '>=4'}
-
   chai@5.1.2:
     resolution: {integrity: sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==}
     engines: {node: '>=12'}
@@ -5220,9 +5192,6 @@ packages:
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
 
-  check-error@1.0.3:
-    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
-
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
@@ -5237,10 +5206,6 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
-
-  chokidar@4.0.1:
-    resolution: {integrity: sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==}
-    engines: {node: '>= 14.16.0'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -5702,10 +5667,6 @@ packages:
       babel-plugin-macros:
         optional: true
 
-  deep-eql@4.1.4:
-    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
-    engines: {node: '>=6'}
-
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -5794,10 +5755,6 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
-
-  diff-sequences@29.6.3:
-    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -6162,14 +6119,6 @@ packages:
     resolution: {integrity: sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==}
     engines: {node: '>=0.8.0'}
 
-  fdir@6.4.2:
-    resolution: {integrity: sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==}
-    peerDependencies:
-      picomatch: ^3 || ^4
-    peerDependenciesMeta:
-      picomatch:
-        optional: true
-
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -6347,9 +6296,6 @@ packages:
   get-east-asian-width@1.3.0:
     resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
     engines: {node: '>=18'}
-
-  get-func-name@2.0.2:
-    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
   get-intrinsic@1.2.7:
     resolution: {integrity: sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==}
@@ -6971,9 +6917,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-tokens@9.0.1:
-    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
-
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
     hasBin: true
@@ -7166,10 +7109,6 @@ packages:
     resolution: {integrity: sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==}
     engines: {node: '>= 12.13.0'}
 
-  local-pkg@0.5.1:
-    resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
-    engines: {node: '>=14'}
-
   locate-path@3.0.0:
     resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
     engines: {node: '>=6'}
@@ -7213,9 +7152,6 @@ packages:
   lodash.snakecase@4.1.1:
     resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
 
-  lodash.sortby@4.7.0:
-    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
-
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
@@ -7246,9 +7182,6 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
-
-  loupe@2.3.7:
-    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
   loupe@3.1.2:
     resolution: {integrity: sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==}
@@ -7792,10 +7725,6 @@ packages:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  p-limit@5.0.0:
-    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
-    engines: {node: '>=18'}
-
   p-locate@3.0.0:
     resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
     engines: {node: '>=6'}
@@ -7928,9 +7857,6 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pathval@1.1.1:
-    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
   pathval@2.0.0:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
@@ -8412,10 +8338,6 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
-  pretty-format@29.7.0:
-    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
   pretty-ms@9.2.0:
     resolution: {integrity: sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==}
     engines: {node: '>=18'}
@@ -8544,9 +8466,6 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
-
-  react-is@18.3.1:
-    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   react-json-view-lite@1.5.0:
     resolution: {integrity: sha512-nWqA1E4jKPklL2jvHWs6s+7Na0qNgw9HCP6xehdQJeg6nPBTFZgGwyko9Q0oj+jQWKTTVRS30u0toM5wiuL3iw==}
@@ -9012,11 +8931,6 @@ packages:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
 
-  source-map@0.8.0-beta.0:
-    resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
-    engines: {node: '>= 8'}
-    deprecated: The work that was done in this beta branch won't be included in future versions
-
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
@@ -9141,9 +9055,6 @@ packages:
     resolution: {integrity: sha512-0fk9zBqO67Nq5M/m45qHCJxylV/DhBlIOVExqgOMiCCrzrhU6tCibRXNqE3jwJLftzE9SNuZtYbpzcO+i9FiKw==}
     engines: {node: '>=14.16'}
 
-  strip-literal@2.1.1:
-    resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
-
   style-to-object@1.0.8:
     resolution: {integrity: sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==}
 
@@ -9260,17 +9171,9 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinyglobby@0.2.10:
-    resolution: {integrity: sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
-
-  tinypool@0.8.4:
-    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
-    engines: {node: '>=14.0.0'}
 
   tinypool@1.0.2:
     resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
@@ -9278,10 +9181,6 @@ packages:
 
   tinyrainbow@1.2.0:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@2.2.1:
-    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@3.0.2:
@@ -9315,9 +9214,6 @@ packages:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
 
-  tr46@1.0.1:
-    resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
-
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
@@ -9345,25 +9241,6 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-
-  tsup@8.3.5:
-    resolution: {integrity: sha512-Tunf6r6m6tnZsG9GYWndg0z8dEV7fD733VBFzFJ5Vcm1FtlXB8xBD/rtrBi2a3YKEV7hHtxiZtW5EAVADoe1pA==}
-    engines: {node: '>=18'}
-    hasBin: true
-    peerDependencies:
-      '@microsoft/api-extractor': ^7.36.0
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: '>=4.5.0'
-    peerDependenciesMeta:
-      '@microsoft/api-extractor':
-        optional: true
-      '@swc/core':
-        optional: true
-      postcss:
-        optional: true
-      typescript:
-        optional: true
 
   tsup@8.5.1:
     resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
@@ -9395,10 +9272,6 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
-
-  type-detect@4.1.0:
-    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
-    engines: {node: '>=4'}
 
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
@@ -9559,11 +9432,6 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite-node@1.6.1:
-    resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-
   vite-node@2.1.8:
     resolution: {integrity: sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -9648,31 +9516,6 @@ packages:
       yaml:
         optional: true
 
-  vitest@1.6.1:
-    resolution: {integrity: sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 1.6.1
-      '@vitest/ui': 1.6.1
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-
   vitest@2.1.8:
     resolution: {integrity: sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -9714,9 +9557,6 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
-
-  webidl-conversions@4.0.2:
-    resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
 
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
@@ -9801,9 +9641,6 @@ packages:
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
-
-  whatwg-url@7.1.0:
-    resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
 
   which-typed-array@1.1.18:
     resolution: {integrity: sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==}
@@ -13847,12 +13684,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@1.6.1':
-    dependencies:
-      '@vitest/spy': 1.6.1
-      '@vitest/utils': 1.6.1
-      chai: 4.5.0
-
   '@vitest/expect@2.0.5':
     dependencies:
       '@vitest/spy': 2.0.5
@@ -13883,32 +13714,16 @@ snapshots:
     dependencies:
       tinyrainbow: 1.2.0
 
-  '@vitest/runner@1.6.1':
-    dependencies:
-      '@vitest/utils': 1.6.1
-      p-limit: 5.0.0
-      pathe: 1.1.2
-
   '@vitest/runner@2.1.8':
     dependencies:
       '@vitest/utils': 2.1.8
       pathe: 1.1.2
-
-  '@vitest/snapshot@1.6.1':
-    dependencies:
-      magic-string: 0.30.14
-      pathe: 1.1.2
-      pretty-format: 29.7.0
 
   '@vitest/snapshot@2.1.8':
     dependencies:
       '@vitest/pretty-format': 2.1.8
       magic-string: 0.30.14
       pathe: 1.1.2
-
-  '@vitest/spy@1.6.1':
-    dependencies:
-      tinyspy: 2.2.1
 
   '@vitest/spy@2.0.5':
     dependencies:
@@ -13917,13 +13732,6 @@ snapshots:
   '@vitest/spy@2.1.8':
     dependencies:
       tinyspy: 3.0.2
-
-  '@vitest/utils@1.6.1':
-    dependencies:
-      diff-sequences: 29.6.3
-      estree-walker: 3.0.3
-      loupe: 2.3.7
-      pretty-format: 29.7.0
 
   '@vitest/utils@2.0.5':
     dependencies:
@@ -14179,8 +13987,6 @@ snapshots:
 
   array-union@2.1.0: {}
 
-  assertion-error@1.1.0: {}
-
   assertion-error@2.0.1: {}
 
   ast-types@0.16.1:
@@ -14341,11 +14147,6 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bundle-require@5.0.0(esbuild@0.24.0):
-    dependencies:
-      esbuild: 0.24.0
-      load-tsconfig: 0.2.5
-
   bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
       esbuild: 0.27.7
@@ -14412,16 +14213,6 @@ snapshots:
 
   ccount@2.0.1: {}
 
-  chai@4.5.0:
-    dependencies:
-      assertion-error: 1.1.0
-      check-error: 1.0.3
-      deep-eql: 4.1.4
-      get-func-name: 2.0.2
-      loupe: 2.3.7
-      pathval: 1.1.1
-      type-detect: 4.1.0
-
   chai@5.1.2:
     dependencies:
       assertion-error: 2.0.1
@@ -14460,10 +14251,6 @@ snapshots:
 
   chardet@0.7.0: {}
 
-  check-error@1.0.3:
-    dependencies:
-      get-func-name: 2.0.2
-
   check-error@2.1.1: {}
 
   cheerio-select@2.1.0:
@@ -14496,10 +14283,6 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
-
-  chokidar@4.0.1:
-    dependencies:
-      readdirp: 4.0.2
 
   chokidar@4.0.3:
     dependencies:
@@ -14954,10 +14737,6 @@ snapshots:
 
   dedent@1.7.2: {}
 
-  deep-eql@4.1.4:
-    dependencies:
-      type-detect: 4.1.0
-
   deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
@@ -15037,8 +14816,6 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
-
-  diff-sequences@29.6.3: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -15565,10 +15342,6 @@ snapshots:
     dependencies:
       websocket-driver: 0.7.4
 
-  fdir@6.4.2(picomatch@4.0.2):
-    optionalDependencies:
-      picomatch: 4.0.2
-
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -15751,8 +15524,6 @@ snapshots:
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.3.0: {}
-
-  get-func-name@2.0.2: {}
 
   get-intrinsic@1.2.7:
     dependencies:
@@ -16451,8 +16222,6 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-tokens@9.0.1: {}
-
   js-yaml@3.14.1:
     dependencies:
       argparse: 1.0.10
@@ -16653,11 +16422,6 @@ snapshots:
 
   loader-utils@3.3.1: {}
 
-  local-pkg@0.5.1:
-    dependencies:
-      mlly: 1.8.2
-      pkg-types: 1.3.1
-
   locate-path@3.0.0:
     dependencies:
       p-locate: 3.0.0
@@ -16693,8 +16457,6 @@ snapshots:
 
   lodash.snakecase@4.1.1: {}
 
-  lodash.sortby@4.7.0: {}
-
   lodash.startcase@4.4.0: {}
 
   lodash.uniq@4.5.0: {}
@@ -16723,10 +16485,6 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
-
-  loupe@2.3.7:
-    dependencies:
-      get-func-name: 2.0.2
 
   loupe@3.1.2: {}
 
@@ -17528,10 +17286,6 @@ snapshots:
     dependencies:
       yocto-queue: 1.1.1
 
-  p-limit@5.0.0:
-    dependencies:
-      yocto-queue: 1.1.1
-
   p-locate@3.0.0:
     dependencies:
       p-limit: 2.3.0
@@ -17654,8 +17408,6 @@ snapshots:
   pathe@1.1.2: {}
 
   pathe@2.0.3: {}
-
-  pathval@1.1.1: {}
 
   pathval@2.0.0: {}
 
@@ -18157,12 +17909,6 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
-  pretty-format@29.7.0:
-    dependencies:
-      '@jest/schemas': 29.6.3
-      ansi-styles: 5.2.0
-      react-is: 18.3.1
-
   pretty-ms@9.2.0:
     dependencies:
       parse-ms: 4.0.0
@@ -18324,8 +18070,6 @@ snapshots:
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
-
-  react-is@18.3.1: {}
 
   react-json-view-lite@1.5.0(react@18.3.1):
     dependencies:
@@ -18971,10 +18715,6 @@ snapshots:
 
   source-map@0.7.6: {}
 
-  source-map@0.8.0-beta.0:
-    dependencies:
-      whatwg-url: 7.1.0
-
   space-separated-tokens@2.0.2: {}
 
   spawndamnit@3.0.1:
@@ -19098,10 +18838,6 @@ snapshots:
 
   strip-json-comments@5.0.1: {}
 
-  strip-literal@2.1.1:
-    dependencies:
-      js-tokens: 9.0.1
-
   style-to-object@1.0.8:
     dependencies:
       inline-style-parser: 0.2.4
@@ -19208,23 +18944,14 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
-  tinyglobby@0.2.10:
-    dependencies:
-      fdir: 6.4.2(picomatch@4.0.2)
-      picomatch: 4.0.2
-
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  tinypool@0.8.4: {}
-
   tinypool@1.0.2: {}
 
   tinyrainbow@1.2.0: {}
-
-  tinyspy@2.2.1: {}
 
   tinyspy@3.0.2: {}
 
@@ -19250,10 +18977,6 @@ snapshots:
     dependencies:
       tldts: 6.1.86
 
-  tr46@1.0.1:
-    dependencies:
-      punycode: 2.3.1
-
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
@@ -19275,33 +18998,6 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
-
-  tsup@8.3.5(jiti@2.4.1)(postcss@8.5.9)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.1):
-    dependencies:
-      bundle-require: 5.0.0(esbuild@0.24.0)
-      cac: 6.7.14
-      chokidar: 4.0.1
-      consola: 3.2.3
-      debug: 4.4.0
-      esbuild: 0.24.0
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.4.1)(postcss@8.5.9)(tsx@4.19.2)(yaml@2.6.1)
-      resolve-from: 5.0.0
-      rollup: 4.28.0
-      source-map: 0.8.0-beta.0
-      sucrase: 3.35.0
-      tinyexec: 0.3.1
-      tinyglobby: 0.2.10
-      tree-kill: 1.2.2
-    optionalDependencies:
-      postcss: 8.5.9
-      typescript: 5.6.3
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
 
   tsup@8.5.1(jiti@2.4.1)(postcss@8.5.9)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.1):
     dependencies:
@@ -19344,8 +19040,6 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
     optional: true
-
-  type-detect@4.1.0: {}
 
   type-fest@0.21.3: {}
 
@@ -19510,24 +19204,6 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@1.6.1(@types/node@22.10.1)(lightningcss@1.32.0)(terser@5.37.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.0
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      vite: 5.4.11(@types/node@22.10.1)(lightningcss@1.32.0)(terser@5.37.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
   vite-node@2.1.8(@types/node@22.10.1)(lightningcss@1.32.0)(terser@5.37.0):
     dependencies:
       cac: 6.7.14
@@ -19594,42 +19270,6 @@ snapshots:
       tsx: 4.19.2
       yaml: 2.6.1
 
-  vitest@1.6.1(@types/node@22.10.1)(happy-dom@15.11.7)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.37.0):
-    dependencies:
-      '@vitest/expect': 1.6.1
-      '@vitest/runner': 1.6.1
-      '@vitest/snapshot': 1.6.1
-      '@vitest/spy': 1.6.1
-      '@vitest/utils': 1.6.1
-      acorn-walk: 8.3.4
-      chai: 4.5.0
-      debug: 4.4.0
-      execa: 8.0.1
-      local-pkg: 0.5.1
-      magic-string: 0.30.14
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      std-env: 3.8.0
-      strip-literal: 2.1.1
-      tinybench: 2.9.0
-      tinypool: 0.8.4
-      vite: 5.4.11(@types/node@22.10.1)(lightningcss@1.32.0)(terser@5.37.0)
-      vite-node: 1.6.1(@types/node@22.10.1)(lightningcss@1.32.0)(terser@5.37.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 22.10.1
-      happy-dom: 15.11.7
-      jsdom: 26.1.0
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
   vitest@2.1.8(@types/node@22.10.1)(happy-dom@15.11.7)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.37.0):
     dependencies:
       '@vitest/expect': 2.1.8
@@ -19685,8 +19325,6 @@ snapshots:
       defaults: 1.0.4
 
   web-namespaces@2.0.1: {}
-
-  webidl-conversions@4.0.2: {}
 
   webidl-conversions@7.0.0: {}
 
@@ -19835,12 +19473,6 @@ snapshots:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
-
-  whatwg-url@7.1.0:
-    dependencies:
-      lodash.sortby: 4.7.0
-      tr46: 1.0.1
-      webidl-conversions: 4.0.2
 
   which-typed-array@1.1.18:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,8 @@ packages:
   - www
 
 catalog:
+  '@faker-js/faker': ^9.2.0
+  '@radix-ui/react-slot': ^1.1.0
   '@storybook/addon-essentials': ^8.4.5
   '@storybook/addon-interactions': ^8.4.5
   '@storybook/addon-links': ^8.4.5
@@ -10,13 +12,17 @@ catalog:
   '@storybook/react': ^8.4.5
   '@storybook/react-vite': ^8.4.5
   '@storybook/test': ^8.4.5
+  '@testing-library/dom': ^10.4.0
   '@testing-library/jest-dom': ^6.6.3
   '@testing-library/react': ^16.0.1
   '@testing-library/user-event': ^14.6.1
   '@vanilla-extract/css': ^1.14.1
+  '@vanilla-extract/dynamic': ^2.1.3
+  '@vanilla-extract/recipes': ^0.5.5
   '@vanilla-extract/esbuild-plugin': ^2.3.15
   '@vanilla-extract/vite-plugin': ^5.0.1
   '@vitest/coverage-v8': ^2.1.8
+  clsx: ^2.1.1
   happy-dom: ^15.7.4
   knip: ^5.34.1
   storybook: ^8.4.7


### PR DESCRIPTION
## Changes

- `pnpm-workspace.yaml`의 `catalog` 항목을 확장해 공통 의존성 버전을 한 곳에서 관리하도록 정리했습니다.
- `packages/*` 전반에서 직접 고정하던 의존성 버전을 `catalog:` 참조로 전환해 버전 관리 방식을 일관되게 맞췄습니다.
- `packages/chip` 패키지명을 `@side/chip`에서 `@sipe-team/chip`으로 변경해 모노레포 네임스페이스 규칙에 맞췄습니다.
- `packages/chip/package.json`의 주요 의존성과 개발 의존성을 모노레포 표준에 맞게 `catalog:` 및 `catalog:react` 기반으로 정리했습니다.
- `packages/chip/tsup.config.ts`가 루트 `tsup.config.ts`를 상속하도록 변경해 `vanilla-extract` 빌드 설정을 공통 설정과 동일하게 맞췄습니다.
- 위 변경에 맞춰 `pnpm-lock.yaml`을 갱신했습니다.

## Visuals

- UI 변경 없음

## Checklist

- [x] Have you written the functional specifications?
- [x] Have you written the test code?

## Additional Discussion Points

- 검증 완료:
  - `pnpm test`
  - `pnpm --filter @sipe-team/chip build`
  - `pnpm --filter @sipe-team/chip test`
  - `pnpm --filter @sipe-team/chip typecheck`
- `packages/chip` 빌드 시 `package.json`의 `exports.types` 순서 관련 warning은 있었지만, 빌드 자체는 정상적으로 완료되었습니다.
- 이번 PR은 의존성 관리 방식 통일과 패키지 설정 표준화가 목적이며, 사용자-facing 동작 변경은 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated dependency management across packages using a centralized catalog system for consistent version control.
  * Updated the chip package identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->