### PR TITLE
fix(build): preserve css imports in sideEffects

### DIFF
--- a/.changeset/spicy-wasps-clap.md
+++ b/.changeset/spicy-wasps-clap.md
@@ -1,0 +1,22 @@
+---
+"@sipe-team/accordion": patch
+"@sipe-team/checkbox": patch
+"@sipe-team/skeleton": patch
+"@sipe-team/divider": patch
+"@sipe-team/tooltip": patch
+"@sipe-team/avatar": patch
+"@sipe-team/button": patch
+"@sipe-team/switch": patch
+"@sipe-team/badge": patch
+"@sipe-team/input": patch
+"@sipe-team/radio": patch
+"@sipe-team/reset": patch
+"@sipe-team/theme": patch
+"@sipe-team/card": patch
+"@sipe-team/chip": patch
+"@sipe-team/flex": patch
+"@sipe-team/grid": patch
+"@sipe-team/side": patch
+---
+
+Preserve CSS imports in `sideEffects` so consumer bundlers don't

--- a/.changeset/spicy-wasps-clap.md
+++ b/.changeset/spicy-wasps-clap.md
@@ -4,19 +4,17 @@
 "@sipe-team/skeleton": patch
 "@sipe-team/divider": patch
 "@sipe-team/tooltip": patch
-"@sipe-team/avatar": patch
 "@sipe-team/button": patch
 "@sipe-team/switch": patch
 "@sipe-team/badge": patch
 "@sipe-team/input": patch
 "@sipe-team/radio": patch
 "@sipe-team/reset": patch
-"@sipe-team/theme": patch
 "@sipe-team/card": patch
-"@sipe-team/chip": patch
 "@sipe-team/flex": patch
 "@sipe-team/grid": patch
 "@sipe-team/side": patch
+"@sipe-team/typography": patch
 ---
 
-Preserve CSS imports in `sideEffects` so consumer bundlers don't
+Preserve CSS imports in `sideEffects` so consumer bundlers don't tree-shake `./styles.css`.

--- a/.templates/component/package.json
+++ b/.templates/component/package.json
@@ -61,6 +61,8 @@
       "./styles.css": "./dist/index.css"
     }
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "**/*.css"
+  ],
   "private": true
 }

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -71,5 +71,7 @@
       "./styles.css": "./dist/index.css"
     }
   },
-  "sideEffects": false
+  "sideEffects": [
+    "**/*.css"
+  ]
 }

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -69,5 +69,7 @@
       "./styles.css": "./dist/index.css"
     }
   },
-  "sideEffects": false
+  "sideEffects": [
+    "**/*.css"
+  ]
 }

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -71,5 +71,7 @@
       "./styles.css": "./dist/index.css"
     }
   },
-  "sideEffects": false
+  "sideEffects": [
+    "**/*.css"
+  ]
 }

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -70,5 +70,7 @@
       "./styles.css": "./dist/index.css"
     }
   },
-  "sideEffects": false
+  "sideEffects": [
+    "**/*.css"
+  ]
 }

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -69,5 +69,7 @@
       "./styles.css": "./dist/index.css"
     }
   },
-  "sideEffects": false
+  "sideEffects": [
+    "**/*.css"
+  ]
 }

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -67,5 +67,7 @@
       "./styles.css": "./dist/index.css"
     }
   },
-  "sideEffects": false
+  "sideEffects": [
+    "**/*.css"
+  ]
 }

--- a/packages/flex/package.json
+++ b/packages/flex/package.json
@@ -68,5 +68,7 @@
       "./styles.css": "./dist/index.css"
     }
   },
-  "sideEffects": false
+  "sideEffects": [
+    "**/*.css"
+  ]
 }

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -67,5 +67,7 @@
       "./styles.css": "./dist/index.css"
     }
   },
-  "sideEffects": false
+  "sideEffects": [
+    "**/*.css"
+  ]
 }

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -70,5 +70,7 @@
       "./styles.css": "./dist/index.css"
     }
   },
-  "sideEffects": false
+  "sideEffects": [
+    "**/*.css"
+  ]
 }

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -71,5 +71,7 @@
       "./styles.css": "./dist/index.css"
     }
   },
-  "sideEffects": false
+  "sideEffects": [
+    "**/*.css"
+  ]
 }

--- a/packages/reset/package.json
+++ b/packages/reset/package.json
@@ -53,5 +53,7 @@
       "./reset.css": "./dist/reset.css"
     }
   },
-  "sideEffects": false
+  "sideEffects": [
+    "**/*.css"
+  ]
 }

--- a/packages/side/package.json
+++ b/packages/side/package.json
@@ -57,5 +57,7 @@
       "./styles.css": "./styles.css"
     }
   },
-  "sideEffects": false
+  "sideEffects": [
+    "**/*.css"
+  ]
 }

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -70,5 +70,7 @@
       "./styles.css": "./dist/index.css"
     }
   },
-  "sideEffects": false
+  "sideEffects": [
+    "**/*.css"
+  ]
 }

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -71,5 +71,7 @@
       "./styles.css": "./dist/index.css"
     }
   },
-  "sideEffects": false
+  "sideEffects": [
+    "**/*.css"
+  ]
 }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -70,5 +70,7 @@
       "./styles.css": "./dist/index.css"
     }
   },
-  "sideEffects": false
+  "sideEffects": [
+    "**/*.css"
+  ]
 }

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -70,5 +70,7 @@
       "./styles.css": "./dist/index.css"
     }
   },
-  "sideEffects": false
+  "sideEffects": [
+    "**/*.css"
+  ]
 }


### PR DESCRIPTION
## Changes

`sideEffects: false`로 선언된 패키지가 `./styles.css`를 함께 export하고 있어, 번들러가 `import '@sipe-team/xxx/styles.css'`를 **tree-shaking으로 제거**해버리는 버그를 수정합니다. 소비자 번들에 스타일이 빠져 UI가 깨지는 원인이 될 수 있음

모든 관련 패키지와 컴포넌트 스캐폴딩 템플릿에서 다음과 같이 변경:

```diff
- "sideEffects": false
+ "sideEffects": ["**/*.css"]
```

**수정된 파일 (17개)**

- **기존 패키지 16개**: `accordion`, `badge`, `button`, `card`, `checkbox`, `divider`, `flex`, `grid`, `input`, `radio`, `reset`, `side`, `skeleton`, `switch`, `tooltip`, `typography`
- **컴포넌트 템플릿 1개**: `.templates/component/package.json` — 앞으로 `pnpm create:component`로 생성되는 모든 신규 패키지가 올바른 설정을 가집니다.

**유지된 패키지 (`sideEffects: false` 그대로)**

CSS export가 없는 다음 패키지는 수정 대상이 아닙니닷:
`avatar`, `icon`, `theme`, `tokens`, `plugin-figma-codegen`

## Checklist

- [x] 전체 패키지 `pnpm -r build` 통과 확인
- [x] Biome 포맷팅 적용
