### PR TITLE
fix(ci): add --if-present flag to pnpm filter commands

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,10 +16,10 @@ jobs:
     - name: Install dependencies
       run: pnpm install
     - name: Lint
-      run: pnpm --filter="...[origin/${{ github.base_ref }}]" lint
+      run: pnpm --filter="...[origin/${{ github.base_ref }}]" --if-present lint
     - name: Test
-      run: pnpm --filter="...[origin/${{ github.base_ref }}]" test
+      run: pnpm --filter="...[origin/${{ github.base_ref }}]" --if-present test
     - name: Type check
-      run: pnpm --filter="...[origin/${{ github.base_ref }}]" typecheck
+      run: pnpm --filter="...[origin/${{ github.base_ref }}]" --if-present typecheck
     - name: Build
-      run: pnpm --filter="...[origin/${{ github.base_ref }}]" build
+      run: pnpm --filter="...[origin/${{ github.base_ref }}]" --if-present build


### PR DESCRIPTION
## 요약

- CI 워크플로우의 모든 `pnpm --filter` 명령에 `--if-present` 플래그 추가
- root `package.json` 변경이 필터에 포함될 때 root 패키지에 `lint`/`test`/`typecheck`/`build` 스크립트가 없어서 발생하는 `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT` 오류 방지

## 관련

- [CI 실패 로그](https://github.com/sipe-team/side/actions/runs/24516476540/job/71661802377?pr=237) — root `package.json` 변경 시 `typecheck` 스크립트가 없어 CI가 실패하는 문제 확인. `--if-present` 플래그를 추가하여 root에서 변경이 일어나도 해당 스크립트가 없는 패키지는 건너뛰고 CI가 정상적으로 동작하도록 수정

## 테스트 계획

- [ ] root 레벨 파일만 수정하는 PR에서 CI 통과 확인
- [x] workspace 패키지 변경이 있는 PR에서 기존처럼 스크립트 정상 실행 확인