### PR TITLE
test(flex): strengthen contract coverage

### DIFF
--- a/packages/flex/src/Flex.stories.tsx
+++ b/packages/flex/src/Flex.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Flex } from './Flex';
+import { FLEX_ALIGNS, FLEX_DIRECTIONS, FLEX_JUSTIFY_CONTENTS, FLEX_WRAPS } from './constants';
 
 const meta = {
   title: 'Components/Flex',
@@ -9,22 +10,22 @@ const meta = {
   argTypes: {
     direction: {
       control: 'select',
-      options: ['row', 'column', 'row-reverse', 'column-reverse'],
+      options: FLEX_DIRECTIONS,
       description: 'Flex direction',
     },
     align: {
       control: 'select',
-      options: ['flex-start', 'flex-end', 'center', 'stretch', 'baseline', 'normal'],
+      options: FLEX_ALIGNS,
       description: 'Align items',
     },
     justify: {
       control: 'select',
-      options: ['flex-start', 'flex-end', 'center', 'space-between', 'space-around', 'space-evenly', 'normal'],
+      options: FLEX_JUSTIFY_CONTENTS,
       description: 'Justify content',
     },
     wrap: {
       control: 'select',
-      options: ['nowrap', 'wrap', 'wrap-reverse'],
+      options: FLEX_WRAPS,
       description: 'Flex wrap',
     },
     gap: {

--- a/packages/flex/src/Flex.test.tsx
+++ b/packages/flex/src/Flex.test.tsx
@@ -1,10 +1,11 @@
-import { type CSSProperties, createElement } from 'react';
+import { type CSSProperties, createElement, createRef } from 'react';
 
 import { faker } from '@faker-js/faker';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
 import { Flex } from './Flex';
+import { FLEX_ALIGNS, FLEX_DIRECTIONS, FLEX_JUSTIFY_CONTENTS, FLEX_WRAPS } from './constants';
 
 describe('Flex', () => {
   it('flex 컴포넌트는 props를 전달하지 않으면 flex의 기본값으로 설정된다.', () => {
@@ -34,16 +35,9 @@ describe('Flex', () => {
 
   describe('flex 속성', () => {
     describe('justify', () => {
-      it.each([
-        { justifyContent: 'flex-start' },
-        { justifyContent: 'flex-end' },
-        { justifyContent: 'center' },
-        { justifyContent: 'space-between' },
-        { justifyContent: 'space-around' },
-        { justifyContent: 'space-evenly' },
-      ] satisfies Array<{
-        justifyContent: CSSProperties['justifyContent'];
-      }>)('flex의 justify prop에 $justifyContent 속성을 주입하면 해당 속성을 적용한다.', ({ justifyContent }) => {
+      it.each(
+        FLEX_JUSTIFY_CONTENTS.map((justifyContent) => ({ justifyContent })),
+      )('flex의 justify prop에 $justifyContent 속성을 주입하면 해당 속성을 적용한다.', ({ justifyContent }) => {
         render(
           <Flex data-testid="flex-container" justify={justifyContent}>
             <div>item 1</div>
@@ -57,15 +51,9 @@ describe('Flex', () => {
     });
 
     describe('align', () => {
-      it.each([
-        { alignItems: 'flex-start' },
-        { alignItems: 'flex-end' },
-        { alignItems: 'center' },
-        { alignItems: 'baseline' },
-        { alignItems: 'stretch' },
-      ] satisfies Array<{
-        alignItems: CSSProperties['alignItems'];
-      }>)('flex의 align prop에 $alignItems 속성을 주입하면 해당 속성을 적용한다.', ({ alignItems }) => {
+      it.each(
+        FLEX_ALIGNS.map((alignItems) => ({ alignItems })),
+      )('flex의 align prop에 $alignItems 속성을 주입하면 해당 속성을 적용한다.', ({ alignItems }) => {
         render(
           <Flex data-testid="flex-container" align={alignItems}>
             <div>item 1</div>
@@ -79,9 +67,9 @@ describe('Flex', () => {
     });
 
     describe('wrap', () => {
-      it.each([{ wrap: 'wrap' }, { wrap: 'nowrap' }, { wrap: 'wrap-reverse' }] satisfies Array<{
-        wrap: CSSProperties['flexWrap'];
-      }>)('flex의 wrap prop에 $wrap 속성을 주입하면 해당 속성을 적용한다.', ({ wrap }) => {
+      it.each(
+        FLEX_WRAPS.map((wrap) => ({ wrap })),
+      )('flex의 wrap prop에 $wrap 속성을 주입하면 해당 속성을 적용한다.', ({ wrap }) => {
         render(
           <Flex data-testid="flex-container" wrap={wrap}>
             <div>item 1</div>
@@ -95,15 +83,9 @@ describe('Flex', () => {
     });
 
     describe('direction', () => {
-      it.each([
-        { direction: 'row' },
-        { direction: 'column' },
-        { direction: 'row-reverse' },
-        { direction: 'column-reverse' },
-        { direction: 'column-reverse' },
-      ] satisfies Array<{
-        direction: CSSProperties['flexDirection'];
-      }>)('flex의 direction prop에 $direction 속성을 주입하면 해당 속성을 적용한다.', ({ direction }) => {
+      it.each(
+        FLEX_DIRECTIONS.map((direction) => ({ direction })),
+      )('flex의 direction prop에 $direction 속성을 주입하면 해당 속성을 적용한다.', ({ direction }) => {
         render(
           <Flex data-testid="flex-container" direction={direction}>
             <div>item 1</div>
@@ -114,89 +96,89 @@ describe('Flex', () => {
         const flexContainer = screen.getByTestId('flex-container');
         expect(flexContainer).toHaveStyle({ flexDirection: direction });
       });
+    });
 
-      describe('basis', () => {
-        it.each([
-          { basis: '100px' },
-          { basis: '100%' },
-          { basis: 'auto' },
-          { basis: '10rem' },
-          { basis: 'content' },
-        ] satisfies Array<{
-          basis: CSSProperties['flexBasis'];
-        }>)('flex의 basis prop에 $basis 속성을 주입하면 해당 속성을 적용한다.', ({ basis }) => {
-          render(
-            <Flex data-testid="flex-container" basis={basis}>
-              <div>item 1</div>
-              <div>item 2</div>
-            </Flex>,
-          );
+    describe('basis', () => {
+      it.each([
+        { basis: '100px' },
+        { basis: '100%' },
+        { basis: 'auto' },
+        { basis: '10rem' },
+        { basis: 'content' },
+      ] satisfies Array<{
+        basis: CSSProperties['flexBasis'];
+      }>)('flex의 basis prop에 $basis 속성을 주입하면 해당 속성을 적용한다.', ({ basis }) => {
+        render(
+          <Flex data-testid="flex-container" basis={basis}>
+            <div>item 1</div>
+            <div>item 2</div>
+          </Flex>,
+        );
 
-          const flexContainer = screen.getByTestId('flex-container');
-          expect(flexContainer).toHaveStyle({ flexBasis: basis });
-        });
+        const flexContainer = screen.getByTestId('flex-container');
+        expect(flexContainer).toHaveStyle({ flexBasis: basis });
       });
+    });
 
-      describe('grow', () => {
-        it.each([{ grow: 0 }, { grow: 1 }, { grow: 2 }] satisfies Array<{
-          grow: CSSProperties['flexGrow'];
-        }>)('flex의 grow prop에 $grow 속성을 주입하면 해당 속성을 적용한다.', ({ grow }) => {
-          render(
-            <Flex data-testid="flex-container" grow={grow}>
-              <div>item 1</div>
-              <div>item 2</div>
-            </Flex>,
-          );
+    describe('grow', () => {
+      it.each([{ grow: 0 }, { grow: 1 }, { grow: 2 }] satisfies Array<{
+        grow: CSSProperties['flexGrow'];
+      }>)('flex의 grow prop에 $grow 속성을 주입하면 해당 속성을 적용한다.', ({ grow }) => {
+        render(
+          <Flex data-testid="flex-container" grow={grow}>
+            <div>item 1</div>
+            <div>item 2</div>
+          </Flex>,
+        );
 
-          const flexContainer = screen.getByTestId('flex-container');
-          expect(flexContainer).toHaveStyle({ flexGrow: grow });
-        });
+        const flexContainer = screen.getByTestId('flex-container');
+        expect(flexContainer).toHaveStyle({ flexGrow: grow });
       });
+    });
 
-      describe('shrink', () => {
-        it.each([{ shrink: 0 }, { shrink: 1 }, { shrink: 2 }] satisfies Array<{
-          shrink: CSSProperties['flexShrink'];
-        }>)('flex의 shrink prop에 $shrink 속성을 주입하면 해당 속성을 적용한다.', ({ shrink }) => {
-          render(
-            <Flex data-testid="flex-container" shrink={shrink}>
-              <div>item 1</div>
-              <div>item 2</div>
-            </Flex>,
-          );
+    describe('shrink', () => {
+      it.each([{ shrink: 0 }, { shrink: 1 }, { shrink: 2 }] satisfies Array<{
+        shrink: CSSProperties['flexShrink'];
+      }>)('flex의 shrink prop에 $shrink 속성을 주입하면 해당 속성을 적용한다.', ({ shrink }) => {
+        render(
+          <Flex data-testid="flex-container" shrink={shrink}>
+            <div>item 1</div>
+            <div>item 2</div>
+          </Flex>,
+        );
 
-          const flexContainer = screen.getByTestId('flex-container');
-          expect(flexContainer).toHaveStyle({ flexShrink: shrink });
-        });
+        const flexContainer = screen.getByTestId('flex-container');
+        expect(flexContainer).toHaveStyle({ flexShrink: shrink });
       });
+    });
 
-      describe('inline', () => {
-        it('flex의 inline prop에 true 속성을 주입하면 해당 속성을 적용한다.', () => {
-          render(
-            <Flex data-testid="flex-container" inline>
-              <div>item 1</div>
-              <div>item 2</div>
-            </Flex>,
-          );
+    describe('inline', () => {
+      it('flex의 inline prop에 true 속성을 주입하면 해당 속성을 적용한다.', () => {
+        render(
+          <Flex data-testid="flex-container" inline>
+            <div>item 1</div>
+            <div>item 2</div>
+          </Flex>,
+        );
 
-          const flexContainer = screen.getByTestId('flex-container');
-          expect(flexContainer).toHaveStyle({ display: 'inline-flex' });
-        });
+        const flexContainer = screen.getByTestId('flex-container');
+        expect(flexContainer).toHaveStyle({ display: 'inline-flex' });
       });
+    });
 
-      describe('gap', () => {
-        it.each([{ gap: '10px' }, { gap: '1rem' }] satisfies Array<{
-          gap: CSSProperties['gap'];
-        }>)('flex의 gap prop에 $gap 속성을 주입하면 해당 속성을 적용한다.', ({ gap }) => {
-          render(
-            <Flex data-testid="flex-container" gap={gap}>
-              <div>item 1</div>
-              <div>item 2</div>
-            </Flex>,
-          );
+    describe('gap', () => {
+      it.each([{ gap: '10px' }, { gap: '1rem' }] satisfies Array<{
+        gap: CSSProperties['gap'];
+      }>)('flex의 gap prop에 $gap 속성을 주입하면 해당 속성을 적용한다.', ({ gap }) => {
+        render(
+          <Flex data-testid="flex-container" gap={gap}>
+            <div>item 1</div>
+            <div>item 2</div>
+          </Flex>,
+        );
 
-          const flexContainer = screen.getByTestId('flex-container');
-          expect(flexContainer).toHaveStyle({ gap });
-        });
+        const flexContainer = screen.getByTestId('flex-container');
+        expect(flexContainer).toHaveStyle({ gap });
       });
     });
   });
@@ -220,6 +202,61 @@ describe('Flex', () => {
       const flexContainer = screen.getByTestId('flex-container');
       expect(flexContainer).toHaveStyle(style);
     });
+
+    it('style prop은 동일한 CSS 속성에 대해 기본 inline style을 override 할 수 있다.', () => {
+      render(
+        <Flex
+          data-testid="flex-container"
+          basis="100px"
+          gap="8px"
+          style={{ flexBasis: '50%', gap: '16px' }}
+        >
+          <div>item 1</div>
+          <div>item 2</div>
+        </Flex>,
+      );
+
+      const flexContainer = screen.getByTestId('flex-container');
+      expect(flexContainer).toHaveStyle({
+        flexBasis: '50%',
+        gap: '16px',
+      });
+    });
+  });
+
+  describe('consumer usage patterns', () => {
+    it('direction, align, gap 조합을 함께 사용해도 의도한 레이아웃 속성을 유지한다.', () => {
+      render(
+        <Flex data-testid="flex-container" direction="column" align="center" gap="12px">
+          <div>item 1</div>
+          <div>item 2</div>
+        </Flex>,
+      );
+
+      const flexContainer = screen.getByTestId('flex-container');
+      expect(flexContainer).toHaveStyle({
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: '12px',
+      });
+    });
+
+    it('inline, justify, gap 조합을 함께 사용해도 의도한 레이아웃 속성을 유지한다.', () => {
+      render(
+        <Flex data-testid="flex-container" inline justify="center" gap="8px">
+          <div>item 1</div>
+          <div>item 2</div>
+        </Flex>,
+      );
+
+      const flexContainer = screen.getByTestId('flex-container');
+      expect(flexContainer).toHaveStyle({
+        display: 'inline-flex',
+        justifyContent: 'center',
+        gap: '8px',
+      });
+    });
   });
 
   describe('polymorphic', () => {
@@ -240,6 +277,45 @@ describe('Flex', () => {
       const flexContainer = screen.getByTestId('flex-container');
       expect(flexContainer).toBeInTheDocument();
       expect(flexContainer.tagName.toLowerCase()).toBe(element);
+    });
+
+    it('asChild 사용 시 className, style, rest props를 자식 element에 전달한다.', () => {
+      render(
+        <Flex
+          asChild
+          className="custom-flex"
+          data-testid="flex-container"
+          aria-label="flex navigation"
+          gap="12px"
+          style={{ padding: '8px' }}
+        >
+          <nav />
+        </Flex>,
+      );
+
+      const flexContainer = screen.getByTestId('flex-container');
+      expect(flexContainer.tagName.toLowerCase()).toBe('nav');
+      expect(flexContainer).toHaveClass('custom-flex');
+      expect(flexContainer).toHaveAttribute('aria-label', 'flex navigation');
+      expect(flexContainer).toHaveStyle({
+        display: 'flex',
+        gap: '12px',
+        padding: '8px',
+      });
+    });
+  });
+
+  describe('ref', () => {
+    it('forwarded ref를 최종 렌더링 DOM node에 전달한다.', () => {
+      const ref = createRef<HTMLDivElement>();
+
+      render(
+        <Flex ref={ref} data-testid="flex-container">
+          <div>item 1</div>
+        </Flex>,
+      );
+
+      expect(ref.current).toBe(screen.getByTestId('flex-container'));
     });
   });
 });

--- a/packages/flex/src/Flex.test.tsx
+++ b/packages/flex/src/Flex.test.tsx
@@ -8,7 +8,7 @@ import { Flex } from './Flex';
 import { FLEX_ALIGNS, FLEX_DIRECTIONS, FLEX_JUSTIFY_CONTENTS, FLEX_WRAPS } from './constants';
 
 describe('Flex', () => {
-  it('flex 컴포넌트는 props를 전달하지 않으면 flex의 기본값으로 설정된다.', () => {
+  it('uses the default flex styles when no props are provided', () => {
     render(
       <Flex data-testid="flex-container">
         <div>item 1</div>
@@ -27,17 +27,17 @@ describe('Flex', () => {
     });
   });
 
-  it('flex 컴포넌트에 className을 주입하면 추가로 전달한다.', () => {
+  it('passes through a custom className', () => {
     const customClassName = faker.word.noun();
     render(<Flex data-testid="flex-container" className={customClassName} />);
     expect(screen.getByTestId('flex-container')).toHaveClass(customClassName);
   });
 
-  describe('flex 속성', () => {
+  describe('flex props', () => {
     describe('justify', () => {
       it.each(
         FLEX_JUSTIFY_CONTENTS.map((justifyContent) => ({ justifyContent })),
-      )('flex의 justify prop에 $justifyContent 속성을 주입하면 해당 속성을 적용한다.', ({ justifyContent }) => {
+      )('applies justifyContent: $justifyContent when justify is provided', ({ justifyContent }) => {
         render(
           <Flex data-testid="flex-container" justify={justifyContent}>
             <div>item 1</div>
@@ -53,7 +53,7 @@ describe('Flex', () => {
     describe('align', () => {
       it.each(
         FLEX_ALIGNS.map((alignItems) => ({ alignItems })),
-      )('flex의 align prop에 $alignItems 속성을 주입하면 해당 속성을 적용한다.', ({ alignItems }) => {
+      )('applies alignItems: $alignItems when align is provided', ({ alignItems }) => {
         render(
           <Flex data-testid="flex-container" align={alignItems}>
             <div>item 1</div>
@@ -69,7 +69,7 @@ describe('Flex', () => {
     describe('wrap', () => {
       it.each(
         FLEX_WRAPS.map((wrap) => ({ wrap })),
-      )('flex의 wrap prop에 $wrap 속성을 주입하면 해당 속성을 적용한다.', ({ wrap }) => {
+      )('applies flexWrap: $wrap when wrap is provided', ({ wrap }) => {
         render(
           <Flex data-testid="flex-container" wrap={wrap}>
             <div>item 1</div>
@@ -85,7 +85,7 @@ describe('Flex', () => {
     describe('direction', () => {
       it.each(
         FLEX_DIRECTIONS.map((direction) => ({ direction })),
-      )('flex의 direction prop에 $direction 속성을 주입하면 해당 속성을 적용한다.', ({ direction }) => {
+      )('applies flexDirection: $direction when direction is provided', ({ direction }) => {
         render(
           <Flex data-testid="flex-container" direction={direction}>
             <div>item 1</div>
@@ -107,7 +107,7 @@ describe('Flex', () => {
         { basis: 'content' },
       ] satisfies Array<{
         basis: CSSProperties['flexBasis'];
-      }>)('flex의 basis prop에 $basis 속성을 주입하면 해당 속성을 적용한다.', ({ basis }) => {
+      }>)('applies flexBasis: $basis when basis is provided', ({ basis }) => {
         render(
           <Flex data-testid="flex-container" basis={basis}>
             <div>item 1</div>
@@ -123,7 +123,7 @@ describe('Flex', () => {
     describe('grow', () => {
       it.each([{ grow: 0 }, { grow: 1 }, { grow: 2 }] satisfies Array<{
         grow: CSSProperties['flexGrow'];
-      }>)('flex의 grow prop에 $grow 속성을 주입하면 해당 속성을 적용한다.', ({ grow }) => {
+      }>)('applies flexGrow: $grow when grow is provided', ({ grow }) => {
         render(
           <Flex data-testid="flex-container" grow={grow}>
             <div>item 1</div>
@@ -139,7 +139,7 @@ describe('Flex', () => {
     describe('shrink', () => {
       it.each([{ shrink: 0 }, { shrink: 1 }, { shrink: 2 }] satisfies Array<{
         shrink: CSSProperties['flexShrink'];
-      }>)('flex의 shrink prop에 $shrink 속성을 주입하면 해당 속성을 적용한다.', ({ shrink }) => {
+      }>)('applies flexShrink: $shrink when shrink is provided', ({ shrink }) => {
         render(
           <Flex data-testid="flex-container" shrink={shrink}>
             <div>item 1</div>
@@ -153,7 +153,7 @@ describe('Flex', () => {
     });
 
     describe('inline', () => {
-      it('flex의 inline prop에 true 속성을 주입하면 해당 속성을 적용한다.', () => {
+      it('renders with inline-flex display when inline is true', () => {
         render(
           <Flex data-testid="flex-container" inline>
             <div>item 1</div>
@@ -169,7 +169,7 @@ describe('Flex', () => {
     describe('gap', () => {
       it.each([{ gap: '10px' }, { gap: '1rem' }] satisfies Array<{
         gap: CSSProperties['gap'];
-      }>)('flex의 gap prop에 $gap 속성을 주입하면 해당 속성을 적용한다.', ({ gap }) => {
+      }>)('applies gap: $gap when gap is provided', ({ gap }) => {
         render(
           <Flex data-testid="flex-container" gap={gap}>
             <div>item 1</div>
@@ -189,7 +189,7 @@ describe('Flex', () => {
       { style: { alignItems: 'center' } },
       { style: { flexWrap: 'wrap' } },
       { style: { flexDirection: 'column' } },
-    ] satisfies Array<{ style: CSSProperties }>)('flex의 style prop에 $style 속성을 주입하면 해당 속성을 적용한다.', ({
+    ] satisfies Array<{ style: CSSProperties }>)('applies style overrides from the style prop: $style', ({
       style,
     }) => {
       render(
@@ -203,7 +203,7 @@ describe('Flex', () => {
       expect(flexContainer).toHaveStyle(style);
     });
 
-    it('style prop은 동일한 CSS 속성에 대해 기본 inline style을 override 할 수 있다.', () => {
+    it('allows the style prop to override inline style values for the same CSS properties', () => {
       render(
         <Flex
           data-testid="flex-container"
@@ -225,7 +225,7 @@ describe('Flex', () => {
   });
 
   describe('consumer usage patterns', () => {
-    it('direction, align, gap 조합을 함께 사용해도 의도한 레이아웃 속성을 유지한다.', () => {
+    it('preserves the expected layout styles when direction, align, and gap are combined', () => {
       render(
         <Flex data-testid="flex-container" direction="column" align="center" gap="12px">
           <div>item 1</div>
@@ -242,7 +242,7 @@ describe('Flex', () => {
       });
     });
 
-    it('inline, justify, gap 조합을 함께 사용해도 의도한 레이아웃 속성을 유지한다.', () => {
+    it('preserves the expected layout styles when inline, justify, and gap are combined', () => {
       render(
         <Flex data-testid="flex-container" inline justify="center" gap="8px">
           <div>item 1</div>
@@ -267,7 +267,7 @@ describe('Flex', () => {
       'input',
       'label',
       'div',
-    ])('flex의 asChild prop에 true 속성을 주입하면 자식으로 %s 엘리먼트가 전달되면 해당 엘리먼트의 태그로 렌더링된다', (element) => {
+    ])('renders as the child %s element when asChild is true', (element) => {
       render(
         <Flex data-testid="flex-container" asChild>
           {createElement(element)}
@@ -279,7 +279,7 @@ describe('Flex', () => {
       expect(flexContainer.tagName.toLowerCase()).toBe(element);
     });
 
-    it('asChild 사용 시 className, style, rest props를 자식 element에 전달한다.', () => {
+    it('passes className, style, and rest props to the child element when asChild is used', () => {
       render(
         <Flex
           asChild
@@ -306,7 +306,7 @@ describe('Flex', () => {
   });
 
   describe('ref', () => {
-    it('forwarded ref를 최종 렌더링 DOM node에 전달한다.', () => {
+    it('forwards the ref to the final rendered DOM node', () => {
       const ref = createRef<HTMLDivElement>();
 
       render(


### PR DESCRIPTION
## 요약

- side 구현 기준으로 Flex 계약 다시 확인함
- Storybook 옵션을 constants 기준으로 정리함
- direction / align / justify / wrap 스토리 옵션을 constants 기준으로 일치시킴
- Flex 테스트 범위를 계약 기준으로 보강함
- normal 값 테스트 추가함
- asChild 동작, style override, ref 전달 테스트 추가함
- consumer 사용 패턴 기준 smoke test 추가함

## 테스트

- packages/flex 단위 vitest 실행함
- 전체 통과 확인함

close : #227 