### PR TITLE
feat(Button): 버튼 컴포넌트의 최소 WAI-ARIA 기본 접근성 개선(#215)

### DIFF
--- a/packages/button/src/Button.css.ts
+++ b/packages/button/src/Button.css.ts
@@ -22,6 +22,10 @@ export const button = recipe({
     transition: 'all 0.2s ease-in-out',
     border: 'none',
     fontFamily: vars.typography.fontFamily,
+    ':focus-visible': {
+      outline: `2px solid ${vars.color.primary}`,
+      outlineOffset: '2px',
+    },
   },
   variants: {
     variant: {

--- a/packages/button/src/Button.test.tsx
+++ b/packages/button/src/Button.test.tsx
@@ -78,3 +78,21 @@ test('large size works correctly', () => {
   expect(button).toBeInTheDocument();
   expect(button.className).toBeTruthy();
 });
+
+test('type="button" is used as default when type is not provided', () => {
+  render(<Button>Test</Button>);
+
+  const button = screen.getByRole('button');
+
+  // Should default to type="button"
+  expect(button).toHaveAttribute('type', 'button');
+});
+
+test('type="submit" works correctly', () => {
+  render(<Button type="submit">Submit</Button>);
+
+  const button = screen.getByRole('button');
+
+  // Should allow overriding type
+  expect(button).toHaveAttribute('type', 'submit');
+});

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -29,6 +29,7 @@ export const Button = forwardRef(function Button(
   {
     variant = ButtonVariant.filled,
     size = ButtonSize.lg,
+    type = 'button',
     asChild,
     disabled,
     className: _className,
@@ -39,5 +40,5 @@ export const Button = forwardRef(function Button(
   const Comp = asChild ? Slot : 'button';
   const className = cx(styles.button({ variant, size }), { [styles.disabled]: disabled }, _className);
 
-  return <Comp ref={ref} className={className} disabled={disabled} {...props} />;
+  return <Comp ref={ref} type={type} className={className} disabled={disabled} {...props} />;
 });


### PR DESCRIPTION
## Changes

Button 컴포넌트에 최소 WAI-ARIA 기본 접근성을 개선했습니다.

- `type="button"` 기본값 추가: 폼 내에서 의도치 않은 submit 동작을 방지합니다. 상위 컴포넌트에서 `type="submit"`으로 오버라이드할 수 있습니다.
- `:focus-visible` 스타일 추가: 키보드 사용자가 버튼에 포커스했을 때 시각적으로 확인할 수 있도록 outline 스타일을 적용합니다.
- 접근성 관련 테스트 2건 추가: `type` 기본값 확인 및 오버라이드 테스트

## Visuals

해당 없음 (CSS outline 스타일은 키보드 Tab 포커스 시에만 표시됩니다)

## Checklist
- [x] Have you written the functional specifications?
- [x] Have you written the test code?

## Additional Discussion Points

- 이번 변경은 기존 API를 변경하지 않으며, 하위 호환성을 유지합니다.
- `type` prop은 기존 `ComponentProps<'button'>`에 이미 포함되어 있으므로 별도 타입 추가 없이 기본값만 설정했습니다.