### PR TITLE
fix(Tooltip): 접근성(a11y) 개선 및 스타일 코드 개선

### DIFF
--- a/.changeset/wet-pants-train.md
+++ b/.changeset/wet-pants-train.md
@@ -1,0 +1,5 @@
+---
+"@sipe-team/tooltip": patch
+---
+
+improve accessibility and refactor styles for Tooltip

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "catalog:",
+    "@vanilla-extract/recipes": "catalog:",
     "clsx": "catalog:"
   },
   "devDependencies": {

--- a/packages/tooltip/src/Tooltip.css.ts
+++ b/packages/tooltip/src/Tooltip.css.ts
@@ -1,120 +1,124 @@
-import { style, styleVariants } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
 
-export const tooltip = style({
-  position: 'fixed',
-  backgroundColor: 'var(--tooltip-bg-color, #000000)',
-  color: '#ffffff',
-  padding: '8px 12px',
-  borderRadius: '8px',
-  fontSize: '12px',
-  lineHeight: 1.5,
-  whiteSpace: 'normal',
-  wordWrap: 'break-word',
-  maxWidth: '250px',
-  boxShadow: '0 4px 8px rgba(0, 0, 0, 0.2)',
-  zIndex: 1000,
-  opacity: 0,
-  transform: 'scale(0.95)',
-  transition: 'opacity 0.3s ease, transform 0.3s ease',
-  pointerEvents: 'none',
-  selectors: {
-    '&.visible': {
-      opacity: 1,
-      transform: 'scale(1)',
-      pointerEvents: 'auto',
-    },
-    '&::after': {
-      content: '""',
-      position: 'absolute',
-      width: 0,
-      height: 0,
-      borderStyle: 'solid',
-    },
-  },
-});
-
-export const placement = styleVariants({
-  'top-left': {
+export const tooltip = recipe({
+  base: {
+    position: 'fixed',
+    backgroundColor: 'var(--tooltip-bg-color, #000000)',
+    color: '#ffffff',
+    padding: '8px 12px',
+    borderRadius: '8px',
+    fontSize: '12px',
+    lineHeight: 1.5,
+    whiteSpace: 'normal',
+    wordWrap: 'break-word',
+    maxWidth: '250px',
+    boxShadow: '0 4px 8px rgba(0, 0, 0, 0.2)',
+    zIndex: 1000,
+    opacity: 0,
+    transform: 'scale(0.95)',
+    transition: 'opacity 0.3s ease, transform 0.3s ease',
+    pointerEvents: 'none',
     selectors: {
+      '&.visible': {
+        opacity: 1,
+        transform: 'scale(1)',
+        pointerEvents: 'auto',
+      },
       '&::after': {
-        bottom: '-6px',
-        left: '8px',
-        borderWidth: '6px 6px 0 6px',
-        borderColor: 'var(--tooltip-bg-color, #000000) transparent transparent transparent',
+        content: '""',
+        position: 'absolute',
+        width: 0,
+        height: 0,
+        borderStyle: 'solid',
       },
     },
   },
-  'top-right': {
-    selectors: {
-      '&::after': {
-        bottom: '-6px',
-        right: '8px',
-        borderWidth: '6px 6px 0 6px',
-        borderColor: 'var(--tooltip-bg-color, #000000) transparent transparent transparent',
+  variants: {
+    placement: {
+      'top-left': {
+        selectors: {
+          '&::after': {
+            bottom: '-6px',
+            left: '8px',
+            borderWidth: '6px 6px 0 6px',
+            borderColor: 'var(--tooltip-bg-color, #000000) transparent transparent transparent',
+          },
+        },
       },
-    },
-  },
-  'bottom-left': {
-    selectors: {
-      '&::after': {
-        top: '-6px',
-        left: '8px',
-        borderWidth: '0 6px 6px 6px',
-        borderColor: 'transparent transparent var(--tooltip-bg-color, #000000) transparent',
+      'top-right': {
+        selectors: {
+          '&::after': {
+            bottom: '-6px',
+            right: '8px',
+            borderWidth: '6px 6px 0 6px',
+            borderColor: 'var(--tooltip-bg-color, #000000) transparent transparent transparent',
+          },
+        },
       },
-    },
-  },
-  'bottom-right': {
-    selectors: {
-      '&::after': {
-        top: '-6px',
-        right: '8px',
-        borderWidth: '0 6px 6px 6px',
-        borderColor: 'transparent transparent var(--tooltip-bg-color, #000000) transparent',
+      'bottom-left': {
+        selectors: {
+          '&::after': {
+            top: '-6px',
+            left: '8px',
+            borderWidth: '0 6px 6px 6px',
+            borderColor: 'transparent transparent var(--tooltip-bg-color, #000000) transparent',
+          },
+        },
       },
-    },
-  },
-  top: {
-    selectors: {
-      '&::after': {
-        bottom: '-6px',
-        left: '50%',
-        transform: 'translateX(-50%)',
-        borderWidth: '6px 6px 0 6px',
-        borderColor: 'var(--tooltip-bg-color, #000000) transparent transparent transparent',
+      'bottom-right': {
+        selectors: {
+          '&::after': {
+            top: '-6px',
+            right: '8px',
+            borderWidth: '0 6px 6px 6px',
+            borderColor: 'transparent transparent var(--tooltip-bg-color, #000000) transparent',
+          },
+        },
       },
-    },
-  },
-  bottom: {
-    selectors: {
-      '&::after': {
-        top: '-6px',
-        left: '50%',
-        transform: 'translateX(-50%)',
-        borderWidth: '0 6px 6px 6px',
-        borderColor: 'transparent transparent var(--tooltip-bg-color, #000000) transparent',
+      top: {
+        selectors: {
+          '&::after': {
+            bottom: '-6px',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            borderWidth: '6px 6px 0 6px',
+            borderColor: 'var(--tooltip-bg-color, #000000) transparent transparent transparent',
+          },
+        },
       },
-    },
-  },
-  left: {
-    selectors: {
-      '&::after': {
-        right: '-6px',
-        top: '50%',
-        transform: 'translateY(-50%)',
-        borderWidth: '6px 0 6px 6px',
-        borderColor: 'transparent transparent transparent var(--tooltip-bg-color, #000000)',
+      bottom: {
+        selectors: {
+          '&::after': {
+            top: '-6px',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            borderWidth: '0 6px 6px 6px',
+            borderColor: 'transparent transparent var(--tooltip-bg-color, #000000) transparent',
+          },
+        },
       },
-    },
-  },
-  right: {
-    selectors: {
-      '&::after': {
-        left: '-6px',
-        top: '50%',
-        transform: 'translateY(-50%)',
-        borderWidth: '6px 6px 6px 0',
-        borderColor: 'transparent var(--tooltip-bg-color, #000000) transparent transparent',
+      left: {
+        selectors: {
+          '&::after': {
+            right: '-6px',
+            top: '50%',
+            transform: 'translateY(-50%)',
+            borderWidth: '6px 0 6px 6px',
+            borderColor: 'transparent transparent transparent var(--tooltip-bg-color, #000000)',
+          },
+        },
+      },
+      right: {
+        selectors: {
+          '&::after': {
+            left: '-6px',
+            top: '50%',
+            transform: 'translateY(-50%)',
+            borderWidth: '6px 6px 6px 0',
+            borderColor: 'transparent var(--tooltip-bg-color, #000000) transparent transparent',
+          },
+        },
       },
     },
   },

--- a/packages/tooltip/src/Tooltip.test.tsx
+++ b/packages/tooltip/src/Tooltip.test.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, test } from 'vitest';
 
+import { calculateTooltipPosition } from './hooks/useTooltip/useTooltip';
 import { Tooltip, type TooltipPosition } from './Tooltip';
 
 describe('Tooltip 기본 동작 테스트', () => {
@@ -154,6 +155,51 @@ describe('Tooltip 접근성 테스트', () => {
     await userEvent.keyboard('{Escape}');
     expect(screen.queryByText('This is a tooltip')).not.toBeInTheDocument();
   });
+
+  test('Space 키를 누르면 click 트리거 Tooltip이 열린다.', async () => {
+    render(
+      <Tooltip tooltipContent="This is a tooltip" trigger="click">
+        <button type="button">Click me</button>
+      </Tooltip>,
+    );
+
+    const trigger = screen.getByText('Click me');
+    trigger.focus();
+
+    await userEvent.keyboard(' ');
+    expect(screen.getByText('This is a tooltip')).toBeInTheDocument();
+  });
+
+  test('trigger 요소에 aria-describedby가 있고 tooltip의 id와 연결된다.', async () => {
+    render(
+      <Tooltip tooltipContent="This is a tooltip">
+        <button type="button">Hover me</button>
+      </Tooltip>,
+    );
+
+    const triggerEl = screen.getByText('Hover me');
+    await userEvent.hover(triggerEl);
+
+    const tooltip = screen.getByRole('tooltip');
+    const wrapper = triggerEl.closest('[aria-describedby]') ?? triggerEl.parentElement;
+    expect(wrapper?.getAttribute('aria-describedby')).toBe(tooltip.id);
+    expect(tooltip.id).toBeTruthy();
+  });
+
+  test('click 트리거일 때 aria-expanded가 열림/닫힘 상태를 반영한다.', async () => {
+    render(
+      <Tooltip tooltipContent="This is a tooltip" trigger="click">
+        <button type="button">Click me</button>
+      </Tooltip>,
+    );
+
+    const triggerEl = screen.getByText('Click me');
+
+    expect(triggerEl).toHaveAttribute('aria-expanded', 'false');
+
+    await userEvent.click(triggerEl);
+    expect(triggerEl).toHaveAttribute('aria-expanded', 'true');
+  });
 });
 
 describe('Tooltip 스타일 테스트', () => {
@@ -172,23 +218,44 @@ describe('Tooltip 스타일 테스트', () => {
     expect(tooltip).toHaveStyle('padding: 20px');
   });
 
-  test('Tooltip이 뷰포트 밖으로 벗어나지 않는다.', async () => {
-    render(
-      <Tooltip tooltipContent="This is a tooltip" placement="bottom">
-        <button type="button" style={{ marginTop: '100vh' }}>
-          Hover me
-        </button>
-      </Tooltip>,
-    );
+  test('trigger가 화면 상단에 붙어있을 때 tooltip이 위로 벗어나지 않는다.', () => {
+    const { top } = calculateTooltipPosition({
+      wrapperRect: { top: 5, bottom: 35, left: 100, right: 200, width: 100, height: 30 } as DOMRect,
+      tooltipRect: { top: 0, left: 0, bottom: 0, right: 0, width: 100, height: 50 } as DOMRect,
+      placement: 'top',
+      gap: 8,
+    });
 
-    const trigger = screen.getByText('Hover me');
-    await userEvent.hover(trigger);
+    expect(top).toBeGreaterThanOrEqual(8);
+  });
 
-    const tooltip = screen.getByText('This is a tooltip');
-    const rect = tooltip.getBoundingClientRect();
+  test('trigger가 화면 하단에 붙어있을 때 tooltip이 아래로 벗어나지 않는다.', () => {
+    const { top } = calculateTooltipPosition({
+      wrapperRect: {
+        top: window.innerHeight - 10,
+        bottom: window.innerHeight,
+        left: 100,
+        right: 200,
+        width: 100,
+        height: 10,
+      } as DOMRect,
+      tooltipRect: { top: 0, left: 0, bottom: 0, right: 0, width: 100, height: 50 } as DOMRect,
+      placement: 'bottom',
+      gap: 8,
+    });
 
-    expect(rect.top).toBeGreaterThanOrEqual(0);
-    expect(rect.bottom).toBeLessThanOrEqual(window.innerHeight);
+    expect(top).toBeLessThanOrEqual(window.innerHeight - 50 - 8);
+  });
+
+  test('trigger가 화면 왼쪽에 붙어있을 때 tooltip이 왼쪽으로 벗어나지 않는다.', () => {
+    const { left } = calculateTooltipPosition({
+      wrapperRect: { top: 100, bottom: 130, left: 5, right: 55, width: 50, height: 30 } as DOMRect,
+      tooltipRect: { top: 0, left: 0, bottom: 0, right: 0, width: 150, height: 40 } as DOMRect,
+      placement: 'left',
+      gap: 8,
+    });
+
+    expect(left).toBeGreaterThanOrEqual(8);
   });
 
   test('긴 텍스트가 툴팁 내에서 줄 바꿈 처리된다.', async () => {
@@ -211,14 +278,14 @@ describe('Tooltip 스타일 테스트', () => {
 });
 
 test('Tooltip이 비동기 데이터로 업데이트된다.', async () => {
-  const fetchMockData = async () => {
-    return new Promise<string>((resolve) => setTimeout(() => resolve('Fetched Content'), 500));
-  };
+  let resolveContent!: (value: string) => void;
 
   const AsyncTooltip = () => {
     const [content, setContent] = useState('Loading...');
     useEffect(() => {
-      fetchMockData().then((data) => setContent(data));
+      new Promise<string>((resolve) => {
+        resolveContent = resolve;
+      }).then((data) => setContent(data));
     }, []);
 
     return (
@@ -231,33 +298,19 @@ test('Tooltip이 비동기 데이터로 업데이트된다.', async () => {
   render(<AsyncTooltip />);
 
   const trigger = screen.getByText('Hover me');
-
   await userEvent.hover(trigger);
 
-  const loadingTooltip = await screen.findByText('Loading...');
-  expect(loadingTooltip).toBeInTheDocument();
+  expect(screen.getByText('Loading...')).toBeInTheDocument();
 
-  const updatedTooltip = await screen.findByText('Fetched Content');
-  expect(updatedTooltip).toBeInTheDocument();
+  await act(async () => {
+    resolveContent('Fetched Content');
+  });
+
+  expect(screen.getByText('Fetched Content')).toBeInTheDocument();
 });
 
 describe('Tooltip asChild 속성 테스트', () => {
-  test('asChild가 true일 경우 자식 요소의 태그가 유지된다.', async () => {
-    render(
-      <Tooltip tooltipContent="This is a tooltip" asChild={true}>
-        <h1>Hover me</h1>
-      </Tooltip>,
-    );
-
-    const childElement = screen.getByText('Hover me');
-    expect(childElement).toHaveProperty('tagName', 'H1');
-
-    await userEvent.hover(childElement);
-    const tooltip = await screen.findByText('This is a tooltip');
-    expect(tooltip).toBeInTheDocument();
-  });
-
-  test('asChild 속성을 주지 않았을 경우, 기본 값으로 동작한다.', async () => {
+  test('asChild 기본값은 true이며 자식 요소의 태그가 유지된다.', async () => {
     render(
       <Tooltip tooltipContent="This is a tooltip">
         <h1>Hover me</h1>
@@ -270,11 +323,6 @@ describe('Tooltip asChild 속성 테스트', () => {
     await userEvent.hover(childElement);
     const tooltip = await screen.findByText('This is a tooltip');
     expect(tooltip).toBeInTheDocument();
-
-    await userEvent.unhover(childElement);
-    await waitFor(() => {
-      expect(screen.queryByText('This is a tooltip')).not.toBeInTheDocument();
-    });
   });
 
   test('asChild가 false일 경우 기본 div로 감싸진다.', async () => {
@@ -284,31 +332,11 @@ describe('Tooltip asChild 속성 테스트', () => {
       </Tooltip>,
     );
 
-    const wrapperElement = screen.getByRole('tooltip');
-    expect(wrapperElement.tagName).toBe('DIV');
-
     const childElement = screen.getByText('Hover me');
-    await userEvent.hover(childElement);
-    const tooltip = await screen.findByText('This is a tooltip');
-    expect(tooltip).toBeInTheDocument();
-  });
-
-  test('asChild가 true일 경우 이벤트 핸들러가 자식 요소에 적용된다.', async () => {
-    render(
-      <Tooltip tooltipContent="This is a tooltip" asChild={true}>
-        <button type="button">Hover me</button>
-      </Tooltip>,
-    );
-
-    const childElement = screen.getByText('Hover me');
+    expect(childElement.parentElement?.tagName).toBe('DIV');
 
     await userEvent.hover(childElement);
     const tooltip = await screen.findByText('This is a tooltip');
     expect(tooltip).toBeInTheDocument();
-
-    await userEvent.unhover(childElement);
-    await waitFor(() => {
-      expect(screen.queryByText('This is a tooltip')).not.toBeInTheDocument();
-    });
   });
 });

--- a/packages/tooltip/src/Tooltip.test.tsx
+++ b/packages/tooltip/src/Tooltip.test.tsx
@@ -7,8 +7,8 @@ import { describe, expect, test } from 'vitest';
 import { calculateTooltipPosition } from './hooks/useTooltip/useTooltip';
 import { Tooltip, type TooltipPosition } from './Tooltip';
 
-describe('Tooltip 기본 동작 테스트', () => {
-  test('Tooltip은 초기 상태에서 보이지 않아야 한다.', () => {
+describe('Tooltip basic behavior', () => {
+  test('Tooltip should not be visible in the initial state.', () => {
     render(
       <Tooltip tooltipContent="Test Tooltip">
         <button type="button">Hover me</button>
@@ -19,7 +19,7 @@ describe('Tooltip 기본 동작 테스트', () => {
     expect(tooltip).not.toBeInTheDocument();
   });
 
-  test('tooltipContent를 주입하지 않으면 Tooltip이 렌더링되지 않는다.', () => {
+  test('Tooltip is not rendered when tooltipContent is not provided.', () => {
     render(
       <Tooltip tooltipContent={null}>
         <button type="button">Hover me</button>
@@ -31,7 +31,7 @@ describe('Tooltip 기본 동작 테스트', () => {
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
   });
 
-  test('hover 트리거일 경우 마우스를 올리면 Tooltip이 나타나고 이탈 시 사라진다.', async () => {
+  test('Tooltip appears on mouse enter and disappears on mouse leave when trigger is hover.', async () => {
     render(
       <Tooltip tooltipContent="This is a tooltip" trigger="hover">
         <button type="button">Hover me</button>
@@ -47,7 +47,7 @@ describe('Tooltip 기본 동작 테스트', () => {
     expect(screen.queryByText('This is a tooltip')).not.toBeInTheDocument();
   });
 
-  test('click 트리거일 경우 클릭하면 Tooltip이 표시되고 다시 클릭하면 사라진다.', async () => {
+  test('Tooltip appears on click and disappears on second click when trigger is click.', async () => {
     render(
       <Tooltip tooltipContent="This is a tooltip" trigger="click">
         <button type="button">Click me</button>
@@ -63,7 +63,7 @@ describe('Tooltip 기본 동작 테스트', () => {
     expect(screen.queryByText('This is a tooltip')).not.toBeInTheDocument();
   });
 
-  test('Tooltip 외부 클릭 시 닫힌다.', async () => {
+  test('Tooltip closes when clicking outside.', async () => {
     render(
       <div>
         <Tooltip tooltipContent="This is a tooltip" trigger="click">
@@ -84,8 +84,8 @@ describe('Tooltip 기본 동작 테스트', () => {
   });
 });
 
-describe('Tooltip 위치 테스트', () => {
-  test('Tooltip이 기본적으로 top 위치에 렌더링된다.', async () => {
+describe('Tooltip placement', () => {
+  test('Tooltip renders at the top position by default.', async () => {
     render(
       <Tooltip tooltipContent="This is a tooltip">
         <button type="button">Hover me</button>
@@ -109,7 +109,7 @@ describe('Tooltip 위치 테스트', () => {
     ['bottom-right'],
     ['left'],
     ['right'],
-  ])('Tooltip이 %s 위치에 올바르게 렌더링된다.', async (placement) => {
+  ])('Tooltip renders correctly at %s position.', async (placement) => {
     render(
       <Tooltip tooltipContent="Tooltip content" placement={placement as TooltipPosition}>
         <button type="button">Trigger</button>
@@ -125,8 +125,8 @@ describe('Tooltip 위치 테스트', () => {
   });
 });
 
-describe('Tooltip 접근성 테스트', () => {
-  test('role="tooltip" 속성이 포함되어 접근성을 보장한다.', async () => {
+describe('Tooltip accessibility', () => {
+  test('role="tooltip" attribute is included to ensure accessibility.', async () => {
     render(
       <Tooltip tooltipContent="This is a tooltip">
         <button type="button">Hover me</button>
@@ -140,7 +140,7 @@ describe('Tooltip 접근성 테스트', () => {
     expect(tooltip).toBeInTheDocument();
   });
 
-  test('Esc 키를 누르면 Tooltip이 닫힌다.', async () => {
+  test('Tooltip closes when pressing the Escape key.', async () => {
     render(
       <Tooltip tooltipContent="This is a tooltip" trigger="click">
         <button type="button">Click me</button>
@@ -156,7 +156,7 @@ describe('Tooltip 접근성 테스트', () => {
     expect(screen.queryByText('This is a tooltip')).not.toBeInTheDocument();
   });
 
-  test('Space 키를 누르면 click 트리거 Tooltip이 열린다.', async () => {
+  test('Tooltip opens when pressing the Space key with click trigger.', async () => {
     render(
       <Tooltip tooltipContent="This is a tooltip" trigger="click">
         <button type="button">Click me</button>
@@ -170,7 +170,7 @@ describe('Tooltip 접근성 테스트', () => {
     expect(screen.getByText('This is a tooltip')).toBeInTheDocument();
   });
 
-  test('trigger 요소에 aria-describedby가 있고 tooltip의 id와 연결된다.', async () => {
+  test('trigger element has aria-describedby linked to the tooltip id.', async () => {
     render(
       <Tooltip tooltipContent="This is a tooltip">
         <button type="button">Hover me</button>
@@ -186,7 +186,7 @@ describe('Tooltip 접근성 테스트', () => {
     expect(tooltip.id).toBeTruthy();
   });
 
-  test('click 트리거일 때 aria-expanded가 열림/닫힘 상태를 반영한다.', async () => {
+  test('aria-expanded reflects the open/closed state when trigger is click.', async () => {
     render(
       <Tooltip tooltipContent="This is a tooltip" trigger="click">
         <button type="button">Click me</button>
@@ -202,8 +202,8 @@ describe('Tooltip 접근성 테스트', () => {
   });
 });
 
-describe('Tooltip 스타일 테스트', () => {
-  test('props로 주입한 backgroundColor와 padding이 CSS 변수에 반영된다.', async () => {
+describe('Tooltip style', () => {
+  test('backgroundColor and padding injected via props are reflected in CSS variables.', async () => {
     render(
       <Tooltip tooltipContent="Styled Tooltip" tooltipStyle={{ backgroundColor: 'red', padding: '20px' }}>
         <button type="button">Hover me</button>
@@ -218,7 +218,7 @@ describe('Tooltip 스타일 테스트', () => {
     expect(tooltip).toHaveStyle('padding: 20px');
   });
 
-  test('trigger가 화면 상단에 붙어있을 때 tooltip이 위로 벗어나지 않는다.', () => {
+  test('Tooltip does not overflow upward when the trigger is near the top of the screen.', () => {
     const { top } = calculateTooltipPosition({
       wrapperRect: { top: 5, bottom: 35, left: 100, right: 200, width: 100, height: 30 } as DOMRect,
       tooltipRect: { top: 0, left: 0, bottom: 0, right: 0, width: 100, height: 50 } as DOMRect,
@@ -229,7 +229,7 @@ describe('Tooltip 스타일 테스트', () => {
     expect(top).toBeGreaterThanOrEqual(8);
   });
 
-  test('trigger가 화면 하단에 붙어있을 때 tooltip이 아래로 벗어나지 않는다.', () => {
+  test('Tooltip does not overflow downward when the trigger is near the bottom of the screen.', () => {
     const { top } = calculateTooltipPosition({
       wrapperRect: {
         top: window.innerHeight - 10,
@@ -247,7 +247,7 @@ describe('Tooltip 스타일 테스트', () => {
     expect(top).toBeLessThanOrEqual(window.innerHeight - 50 - 8);
   });
 
-  test('trigger가 화면 왼쪽에 붙어있을 때 tooltip이 왼쪽으로 벗어나지 않는다.', () => {
+  test('Tooltip does not overflow to the left when the trigger is near the left edge of the screen.', () => {
     const { left } = calculateTooltipPosition({
       wrapperRect: { top: 100, bottom: 130, left: 5, right: 55, width: 50, height: 30 } as DOMRect,
       tooltipRect: { top: 0, left: 0, bottom: 0, right: 0, width: 150, height: 40 } as DOMRect,
@@ -258,7 +258,7 @@ describe('Tooltip 스타일 테스트', () => {
     expect(left).toBeGreaterThanOrEqual(8);
   });
 
-  test('긴 텍스트가 툴팁 내에서 줄 바꿈 처리된다.', async () => {
+  test('Long text wraps within the tooltip container.', async () => {
     render(
       <Tooltip
         tooltipContent="This is a very long tooltip text that should wrap within the tooltip container to avoid overflowing the screen."
@@ -277,7 +277,7 @@ describe('Tooltip 스타일 테스트', () => {
   });
 });
 
-test('Tooltip이 비동기 데이터로 업데이트된다.', async () => {
+test('Tooltip updates with async data.', async () => {
   let resolveContent!: (value: string) => void;
 
   const AsyncTooltip = () => {
@@ -309,8 +309,8 @@ test('Tooltip이 비동기 데이터로 업데이트된다.', async () => {
   expect(screen.getByText('Fetched Content')).toBeInTheDocument();
 });
 
-describe('Tooltip asChild 속성 테스트', () => {
-  test('asChild 기본값은 true이며 자식 요소의 태그가 유지된다.', async () => {
+describe('Tooltip asChild prop', () => {
+  test('asChild defaults to true and preserves the child element tag.', async () => {
     render(
       <Tooltip tooltipContent="This is a tooltip">
         <h1>Hover me</h1>
@@ -325,7 +325,7 @@ describe('Tooltip asChild 속성 테스트', () => {
     expect(tooltip).toBeInTheDocument();
   });
 
-  test('asChild가 false일 경우 기본 div로 감싸진다.', async () => {
+  test('When asChild is false, the child is wrapped in a default div.', async () => {
     render(
       <Tooltip tooltipContent="This is a tooltip" asChild={false}>
         <button type="button">Hover me</button>

--- a/packages/tooltip/src/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip.tsx
@@ -4,6 +4,7 @@ import {
   type ForwardedRef,
   forwardRef,
   type ReactNode,
+  useId,
   useImperativeHandle,
 } from 'react';
 import { createPortal } from 'react-dom';
@@ -15,17 +16,23 @@ import clsx from 'clsx';
 import { useTooltip } from './hooks/useTooltip';
 import * as styles from './Tooltip.css';
 
-export type TooltipPosition =
-  | 'top-left'
-  | 'top'
-  | 'top-right'
-  | 'bottom-left'
-  | 'bottom'
-  | 'bottom-right'
-  | 'left'
-  | 'right';
+export const TooltipPosition = {
+  'top-left': 'top-left',
+  top: 'top',
+  'top-right': 'top-right',
+  'bottom-left': 'bottom-left',
+  bottom: 'bottom',
+  'bottom-right': 'bottom-right',
+  left: 'left',
+  right: 'right',
+} as const;
+export type TooltipPosition = (typeof TooltipPosition)[keyof typeof TooltipPosition];
 
-export type TooltipTrigger = 'hover' | 'click';
+export const TooltipTrigger = {
+  hover: 'hover',
+  click: 'click',
+} as const;
+export type TooltipTrigger = (typeof TooltipTrigger)[keyof typeof TooltipTrigger];
 
 export interface TooltipProps extends ComponentProps<'div'> {
   tooltipContent: ReactNode;
@@ -40,8 +47,8 @@ export interface TooltipProps extends ComponentProps<'div'> {
 export const Tooltip = forwardRef(function Tooltip(
   {
     tooltipContent,
-    placement: placementProp = 'top',
-    trigger = 'hover',
+    placement: placementProp = TooltipPosition.top,
+    trigger = TooltipTrigger.hover,
     asChild = true,
     children,
     tooltipStyle,
@@ -50,6 +57,7 @@ export const Tooltip = forwardRef(function Tooltip(
   }: TooltipProps,
   ref: ForwardedRef<HTMLElement>,
 ) {
+  const tooltipId = useId();
   const { isVisible, toggleTooltip, tooltipStyles, wrapperRef, tooltipRef, handleKeyDown } = useTooltip({
     placement: placementProp,
     gap,
@@ -68,12 +76,13 @@ export const Tooltip = forwardRef(function Tooltip(
     <>
       <Component
         ref={wrapperRef}
-        role="tooltip"
-        onMouseEnter={trigger === 'hover' ? () => toggleTooltip(true) : undefined}
-        onMouseLeave={trigger === 'hover' ? () => toggleTooltip(false) : undefined}
-        onClick={trigger === 'click' ? () => toggleTooltip(!isVisible) : undefined}
+        aria-describedby={isVisible ? tooltipId : undefined}
+        aria-expanded={trigger === TooltipTrigger.click ? isVisible : undefined}
+        onMouseEnter={trigger === TooltipTrigger.hover ? () => toggleTooltip(true) : undefined}
+        onMouseLeave={trigger === TooltipTrigger.hover ? () => toggleTooltip(false) : undefined}
+        onClick={trigger === TooltipTrigger.click ? () => toggleTooltip(!isVisible) : undefined}
         onKeyDown={handleKeyDown}
-        tabIndex={trigger === 'click' ? 0 : undefined}
+        tabIndex={trigger === TooltipTrigger.click ? 0 : undefined}
         className={styles.button}
       >
         {children}
@@ -81,8 +90,10 @@ export const Tooltip = forwardRef(function Tooltip(
       {isVisible &&
         createPortal(
           <div
+            id={tooltipId}
             ref={tooltipRef}
-            className={clsx(styles.tooltip, styles.placement[placementProp], tooltipClassName, isVisible && 'visible')}
+            role="tooltip"
+            className={clsx(styles.tooltip({ placement: placementProp }), tooltipClassName, isVisible && 'visible')}
             style={
               {
                 ...tooltipStyles,

--- a/packages/tooltip/src/hooks/useTooltip/useTooltip.tsx
+++ b/packages/tooltip/src/hooks/useTooltip/useTooltip.tsx
@@ -1,7 +1,6 @@
 import { type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, useEffect, useRef, useState } from 'react';
 
-import type { TooltipPosition } from '../../Tooltip';
-import { TooltipTrigger } from '../../Tooltip';
+import type { TooltipPosition, TooltipTrigger } from '../../Tooltip';
 
 interface useTooltipProps {
   placement: TooltipPosition;
@@ -79,7 +78,7 @@ export function useTooltip({ placement, gap, trigger }: useTooltipProps) {
   };
 
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
-    if ((event.code === 'Enter' || event.code === 'Space') && trigger === TooltipTrigger.click) {
+    if ((event.code === 'Enter' || event.code === 'Space') && trigger === 'click') {
       event.preventDefault();
       toggleTooltip(!isVisible);
     }

--- a/packages/tooltip/src/hooks/useTooltip/useTooltip.tsx
+++ b/packages/tooltip/src/hooks/useTooltip/useTooltip.tsx
@@ -1,6 +1,7 @@
 import { type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, useEffect, useRef, useState } from 'react';
 
-import type { TooltipPosition, TooltipTrigger } from '../../Tooltip';
+import type { TooltipPosition } from '../../Tooltip';
+import { TooltipTrigger } from '../../Tooltip';
 
 interface useTooltipProps {
   placement: TooltipPosition;
@@ -78,7 +79,7 @@ export function useTooltip({ placement, gap, trigger }: useTooltipProps) {
   };
 
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
-    if ((event.code === 'Enter' || event.code === 'Space') && trigger === 'click') {
+    if ((event.code === 'Enter' || event.code === 'Space') && trigger === TooltipTrigger.click) {
       event.preventDefault();
       toggleTooltip(!isVisible);
     }

--- a/packages/tooltip/src/hooks/useTooltip/useTooltip.tsx
+++ b/packages/tooltip/src/hooks/useTooltip/useTooltip.tsx
@@ -63,6 +63,14 @@ export function useTooltip({ placement, gap, trigger }: useTooltipProps) {
     };
 
     handlePosition();
+
+    window.addEventListener('scroll', handlePosition, true);
+    window.addEventListener('resize', handlePosition);
+
+    return () => {
+      window.removeEventListener('scroll', handlePosition, true);
+      window.removeEventListener('resize', handlePosition);
+    };
   }, [isVisible, gap, placement]);
 
   const toggleTooltip = (visible: boolean) => {
@@ -70,7 +78,7 @@ export function useTooltip({ placement, gap, trigger }: useTooltipProps) {
   };
 
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
-    if ((event.code === 'Enter' || event.code === 'space') && trigger === 'click') {
+    if ((event.code === 'Enter' || event.code === 'Space') && trigger === 'click') {
       event.preventDefault();
       toggleTooltip(!isVisible);
     }

--- a/packages/tooltip/src/hooks/useTooltip/useTooltip.tsx
+++ b/packages/tooltip/src/hooks/useTooltip/useTooltip.tsx
@@ -94,13 +94,18 @@ export function useTooltip({ placement, gap, trigger }: useTooltipProps) {
   };
 }
 
-interface CalculateTooltipPositionParams {
+export interface CalculateTooltipPositionParams {
   wrapperRect: DOMRect;
   tooltipRect: DOMRect;
   placement: TooltipPosition;
   gap: number;
 }
-function calculateTooltipPosition({ wrapperRect, tooltipRect, placement, gap }: CalculateTooltipPositionParams): {
+export function calculateTooltipPosition({
+  wrapperRect,
+  tooltipRect,
+  placement,
+  gap,
+}: CalculateTooltipPositionParams): {
   top: number;
   left: number;
 } {

--- a/packages/tooltip/src/hooks/useTooltip/useTooltip.tsx
+++ b/packages/tooltip/src/hooks/useTooltip/useTooltip.tsx
@@ -94,7 +94,7 @@ export function useTooltip({ placement, gap, trigger }: useTooltipProps) {
   };
 }
 
-export interface CalculateTooltipPositionParams {
+interface CalculateTooltipPositionParams {
   wrapperRect: DOMRect;
   tooltipRect: DOMRect;
   placement: TooltipPosition;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1449,6 +1449,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: 'catalog:'
         version: 1.1.0(@types/react@18.3.13)(react@18.3.1)
+      '@vanilla-extract/recipes':
+        specifier: 'catalog:'
+        version: 0.5.7(@vanilla-extract/css@1.20.1)
       clsx:
         specifier: 'catalog:'
         version: 2.1.1


### PR DESCRIPTION
## Changes
* role="tooltip"을 trigger wrapper가 아닌 실제 tooltip 엘리먼트에 배치하고, useId로 생성한 id로 aria-describedby 연결
* click trigger일 때 aria-expanded로 열림/닫힘 상태 노출
* Space/Enter 키 이벤트 처리 버그 수정 ('space' → 'Space')
* scroll/resize 시 tooltip 위치 재계산 추가
* styleVariants → vanilla-extract recipe()로 스타일 구조 통일
* TooltipPosition, TooltipTrigger를 string literal type에서 enum-style const 객체로 변환

## Visuals
### as-is
https://github.com/user-attachments/assets/93f5a7b8-7d34-44c7-bca8-f0cff4a40f46
### to-be

https://github.com/user-attachments/assets/bbe8dd85-e423-409e-80e5-47da035f8e42

## Checklist
- [x] Have you written the functional specifications?
- [x] Have you written the test code?

## Additional Discussion Points
~~현재 테스트 코드가 컴포넌트마다 한글/영어로 혼재되어 있어요. 어느 언어로 통일하면 좋을지 한번 같이 이야기해보면 좋을 것 같습니다! 🙂~~(논의완)