### PR TITLE
docs: SIDE v2 토큰 아키텍처 및 네이밍 컨벤션 설계 문서 추가

### DIFF
--- a/.github/decisions/token-architecture.md
+++ b/.github/decisions/token-architecture.md
@@ -1,0 +1,331 @@
+# SIDE v2 토큰 아키텍처
+
+## 1. 레퍼런스 디자인 시스템 비교
+
+| 시스템 | 계층 수 | Primitive 키 | Semantic 키 예시 | 다크모드 전환 | 비고 |
+|---|---|---|---|---|---|
+| **Toss TDS** | 2 (Primitive → Semantic) | `blue-500` | `color-background-primary` | `data-tds-theme` attribute | Semantic만 CSS var 노출 |
+| **Atlassian** | 3 (Base → Semantic → Component) | `color.blue.500` | `color.text.accent.blue` | `data-color-mode` attribute | Component 계층이 방대해 유지보수 부담 |
+| **Adobe Spectrum** | 3 (Global → Alias → Component) | `--spectrum-blue-500` | `--spectrum-accent-color-default` | CSS selector 교체 | Alias = Semantic, 가장 세분화 |
+| **shadcn/ui** ⚠️ | 2 (Scale → Semantic) | 직접 노출 안 함 | `--background`, `--primary` | `.dark` class | 컴포넌트 모음이지 디자인 시스템이 아님 — 토큰 구조 레퍼런스로만 참고 |
+| **Radix Colors** ⚠️ | 1 (Primitive scale 제공) | `--blue-9` (12단계) | Semantic은 소비자가 정의 | 별도 dark scale 제공 | 색상 팔레트 도구 — 디자인 시스템 아님. 단계별 의미 고정(9=solid, 11=text)이 Primitive 설계에 참고할 만함 |
+| **11번가** | 2 (Brand → Semantic) | `Gray_01`, `11STREET_Red` | `text-primary`, `icon-disabled` | 없음 (라이트 전용) | 브랜드 색상 중심; CSS var 기반 테마 없음 |
+| **쏘카 SOCARFRAME 2.0** | 3 (Primitive → Semantic → Component) | `tw-blue-100` | `tw-text-primary-strong` | `data-theme` attribute | Tailwind 기반 — VE 미사용; Figma Code Connect 연동 |
+| **G마켓 GDS** | 2 (Core Palette → Semantic) | `Green-500`, `Gray-900` | `text-primary`, `bg-white` | 없음 (라이트 전용) | 2021년 v1.0; WCAG 2.0 기반 색상 스케일 |
+| **라인 LDSM** | 2+ (Primitive → Semantic 확인) | 미공개 (SPA 렌더링) | `line-semantic-colors` | 미확인 | Semantic 계층 존재 확인; 컴포넌트 라이브러리 규모 큼 |
+| **카카오스타일 지그재그** ✅ | 2 (Primitive → Semantic) | 미공개 | — | `data-theme` attribute | **VE `createGlobalThemeContract` 사용** — 현 프로젝트와 구조 가장 유사 |
+
+- **Toss**: Component 계층은 컴포넌트 `.css.ts` 내부 변수로 처리해서 2계층으로 충분함
+- **Atlassian**: Component 계층을 토큰 패키지에 넣으면 컴포넌트 변경마다 토큰 패키지 릴리스가 강제되는 결합이 생김
+- **Radix Colors**: 단계별 의미를 고정한 방식(9=solid bg, 11=text)이 Semantic 색상 역할 분리에 참고할 만함
+- **shadcn/ui**: HSL 분리 대신 opacity 변형이 필요한 색상은 별도 토큰으로 명시하는 게 VE 방식에 더 맞음
+- **카카오스타일**: VE 기반 한국 디자인 시스템 중 가장 직접적인 레퍼런스 — [기술 블로그](https://devblog.kakaostyle.com/ko/2024-12-13-1-rebuilding-frontend-design-system/) 참고
+
+---
+
+## 2. 계층 구조 결정
+
+```
+┌──────────────────────────────────────────────────┐
+│  Semantic Layer  (목적·의미 기반 alias)           │
+│  vars.color.text.primary                         │
+│  vars.color.bg.surface                           │
+│  CSS: --side-color-text-primary                  │
+└────────────────────┬─────────────────────────────┘
+                     │ alias only
+┌────────────────────▼─────────────────────────────┐
+│  Primitive Layer  (원시값 척도)                   │
+│  vars.color.blue[500]                            │
+│  vars.spacing[4]                                 │
+│  CSS: --side-color-blue-500                      │
+└──────────────────────────────────────────────────┘
+```
+
+## 3. 계층별 허용 범위 원칙
+
+### Primitive Layer
+
+- hex, px, rem, ms, 숫자 스케일 값 등 원시값만 허용
+- 다른 토큰 참조, 의미론적 이름 사용은 하지 않음 
+- 라이트/다크 모드에 따라 값이 바뀌지 않는다 — 순수 팔레트
+
+```json
+// 올바른 예
+{ "color": { "blue": { "500": "#3b82f6" } } }
+
+// 금지 예 — Primitive에 Semantic 명명을 쓰는 것
+{ "color": { "primary": "#3b82f6" } }
+```
+
+### Semantic Layer
+
+- Primitive token에 대한 alias만 허용
+- hex, px 등 원시값 직접 사용 금지
+- 모드(light/dark)마다 **동일 키에 다른 Primitive를 할당**하는 방식으로 구현
+
+```json
+// 올바른 예 — Primitive alias
+{ "color": { "text": { "primary": "{color.gray.950}" } } }
+
+// 금지 예 — Primitive 값 직접 기입
+{ "color": { "text": { "primary": "#131518" } } }
+```
+
+---
+
+## 4. Vanilla Extract 파일 역할 정의
+
+### 파일 목록
+
+```
+packages/tokens/src/
+├── primitive/
+│   └── theme.css.ts         # createGlobalTheme — 단일 구현, contract 불필요
+├── semantic/
+│   ├── contract.css.ts      # createGlobalThemeContract (prefix 적용) — Semantic CSS var 계약 선언
+│   ├── _values.ts           # light/dark 순수 값 객체 (CSS 생성 없음)
+│   ├── light.css.ts         # createGlobalTheme(':root', ...) — 라이트 모드 값
+│   └── dark.css.ts          # createGlobalTheme + globalStyle @media — 다크 모드 값
+└── index.ts                 # vars (semantic)만 re-export
+```
+
+### `primitive/theme.css.ts`
+
+구현체가 하나뿐이므로 contract 없이 `createGlobalTheme`만으로 충분하다. 반환값 `primitiveVars`는 패키지 내부(`semantic/`)에서만 참조하며 외부로 노출하지 않는다.
+
+```ts
+import { createGlobalTheme } from '@vanilla-extract/css';
+
+// 단일 전역 주입 — 모드와 무관하게 항상 동일한 값
+// primitiveVars는 semantic 계층 내부 전용 — index.ts에서 export하지 않는다
+export const primitiveVars = createGlobalTheme(':root', {
+  color: {
+    blue: { '500': '#3b82f6', '600': '#2563eb' },
+    gray: { '50': '#fafafa', '950': '#111111' },
+  },
+  spacing: { '1': '4px', '2': '8px' },
+  // ...
+});
+```
+
+### `semantic/contract.css.ts`
+
+```ts
+import { createGlobalThemeContract } from '@vanilla-extract/css';
+
+export const vars = createGlobalThemeContract(
+  {
+    color: {
+      text: { primary: null, secondary: null, disabled: null, inverse: null, /* ... */ },
+      bg: { base: null, surface: null, overlay: null, /* ... */ },
+      border: { default: null, focused: null, error: null, /* ... */ },
+      icon: { default: null, secondary: null, disabled: null },
+      status: { success: null, warning: null, error: null, info: null },
+      // 테마 브랜드 색상
+      brand: { primary: null, secondary: null, gradient: null },
+    },
+    // Semantic spacing/radius는 Primitive를 그대로 alias
+    // 컴포넌트에서 vars.radius.md 처럼 쓰기 위해 재노출
+    radius: { none: null, sm: null, md: null, lg: null, xl: null, full: null },
+  },
+  (_, path) => `side-${path.join('-')}`,
+);
+```
+
+### `semantic/_values.ts`
+
+CSS를 생성하지 않는 순수 값 객체. `light.css.ts`와 `dark.css.ts` 두 파일이 동일한 값 객체를 각각 참조해야 하므로 별도 분리한다.
+
+```ts
+// _values.ts
+import { primitiveVars } from '../primitive/theme.css';
+
+export const lightValues = {
+  color: {
+    text: {
+      primary: primitiveVars.color.gray['950'],
+      secondary: primitiveVars.color.gray['600'],
+      disabled: primitiveVars.color.gray['400'],
+      inverse: primitiveVars.color.gray['50'],
+    },
+    bg: {
+      base: primitiveVars.color.gray['50'],
+      surface: primitiveVars.color.white,
+    },
+    brand: {
+      primary: '#f4a1a0',  // 예외: 브랜드 색은 테마별 고유값
+    },
+    // ...
+  },
+  radius: primitiveVars.radius,
+  // ...
+};
+
+export const darkValues = {
+  color: {
+    text: {
+      primary: primitiveVars.color.gray['50'],
+      secondary: primitiveVars.color.gray['400'],
+      disabled: primitiveVars.color.gray['600'],
+      inverse: primitiveVars.color.gray['950'],
+    },
+    bg: {
+      base: primitiveVars.color.gray['950'],
+      surface: primitiveVars.color.gray['900'],
+    },
+    // ...
+  },
+  // ...
+};
+```
+
+### `semantic/dark.css.ts`
+
+다크 모드가 기본값이므로 `:root`에 darkValues를 주입한다.
+
+```ts
+import { createGlobalTheme } from '@vanilla-extract/css';
+import { vars } from './contract.css';
+import { darkValues } from './_values';
+
+// 기본값: 다크 모드
+createGlobalTheme(':root', vars, darkValues);
+```
+
+### `semantic/light.css.ts`
+
+`createGlobalTheme`은 빌드타임 함수라 미디어 쿼리 안에 직접 넣을 수 없다. `data-mode="light"` 단독으로는 `prefers-color-scheme: light` 유저를 JS 토글 없이 커버할 수 없으므로 `globalStyle`로 시스템 라이트모드를 별도 처리한다.
+
+우선순위: `[data-mode="light"]` selector specificity > `@media` → `data-mode`가 명시된 경우 항상 우선된다. 단, 사용자가 시스템을 라이트로 설정했는데 `data-mode="dark"`가 명시된 경우 `@media`가 이겨버리는 충돌이 생기므로 이를 방어하는 `[data-mode="dark"]` override를 추가한다.
+
+```ts
+import { assignVars, createGlobalTheme, globalStyle } from '@vanilla-extract/css';
+import { vars } from './contract.css';
+import { darkValues, lightValues } from './_values';
+
+// ① JS 토글 방식 (data-mode attribute 기반)
+createGlobalTheme('[data-mode="light"]', vars, lightValues);
+
+// ② 시스템 라이트모드 (JS 토글 없이도 동작)
+globalStyle('body', {
+  '@media': {
+    '(prefers-color-scheme: light)': {
+      vars: assignVars(vars, lightValues),
+    },
+  },
+});
+
+// ③ data-mode="dark" 명시 시 @media를 덮어씀 (우선순위 방어)
+globalStyle('[data-mode="dark"]', {
+  vars: assignVars(vars, darkValues),
+});
+```
+
+> **설계 원칙**: `light.css.ts` / `dark.css.ts`는 **codegen 대상**이다. `tokens/**/*.json`에서 자동 생성되며, 수동 편집하지 않는다. `contract.css.ts`는 타입 계약이므로 JSON 스키마 변경 시 함께 갱신된다.
+
+---
+
+## 5. 다크 모드 확장성
+
+### 파일 구조
+
+```
+tokens/
+├── primitive/
+│   ├── color.json          # 불변 팔레트 (모드 무관)
+│   ├── spacing.json
+│   ├── radius.json
+│   └── typography.json
+└── semantic/
+    ├── light/
+    │   └── color.json      # 라이트 모드 alias 맵
+    ├── dark/
+    │   └── color.json      # 다크 모드 alias 맵
+    └── brand/
+        ├── 1st.json        # 각 SIPE 기수별 브랜드 색
+        ├── 2nd.json
+        ├── 3rd.json
+        └── 4th.json
+```
+
+### Theme Switching 메커니즘
+
+```
+<html data-mode="light" data-theme="4th">
+  → vars가 semantic/light + brand/4th 조합으로 결정됨
+
+<html data-mode="dark" data-theme="4th">
+  → vars가 semantic/dark + brand/4th 조합으로 결정됨
+```
+
+CSS 우선순위:
+1. `:root` — 기본 다크 모드 (4th 테마)
+2. `@media (prefers-color-scheme: light)` — 시스템 라이트모드 (JS 토글 없이 동작)
+3. `[data-mode="light"]` — 라이트 모드 명시 override (②보다 specificity 높음)
+4. `[data-mode="dark"]` — 다크 모드 명시 override (②의 @media 충돌 방어)
+5. `[data-theme="Nth"]` — 브랜드 색상 override (primary, secondary, gradient)
+
+### Tokens Studio Sets 구조
+
+```
+Sets:
+  - primitive/color        (global, always active)
+  - primitive/spacing      (global, always active)
+  - primitive/radius       (global, always active)
+  - primitive/typography   (global, always active)
+  - semantic/light/color   (theme set: mode=light)
+  - semantic/dark/color    (theme set: mode=dark)
+  - brand/1st              (theme set: theme=1st)
+  - brand/2nd              (theme set: theme=2nd)
+  - brand/3rd              (theme set: theme=3rd)
+  - brand/4th              (theme set: theme=4th)
+```
+
+---
+
+## 6. Vanilla Extract Contract 패턴
+
+### createGlobalThemeContract의 역할
+
+`createGlobalThemeContract`는 **타입의 근거**다:
+- CSS 변수명을 매핑 함수 하나로 일관되게 결정한다.
+- TypeScript 타입을 생성해 잘못된 토큰 참조를 컴파일 타임에 잡는다.
+- `createGlobalTheme`에 값 주입 시 계약 키를 모두 채웠는지 타입으로 강제한다.
+
+```ts
+// contract가 있으면 이 코드는 타입 에러
+createGlobalTheme(':root', vars, {
+  color: { text: { primary: '#000' } }
+  // TS Error: color.text.secondary 누락
+});
+```
+
+### 컴포넌트에서의 사용
+
+```ts
+// packages/button/src/Button.css.ts
+import { vars } from '@sipe-team/tokens'; // Semantic vars만 import
+
+export const buttonRecipe = recipe({
+  base: {
+    backgroundColor: vars.color.bg.surface,
+    color: vars.color.text.primary,
+    borderRadius: vars.radius.md,
+  },
+  variants: {
+    variant: {
+      primary: {
+        backgroundColor: vars.color.brand.primary,
+      },
+    },
+  },
+});
+```
+
+컴포넌트는 **Semantic vars만** import한다. `primitiveVars`는 `semantic/` 내부에서만 참조하며, `index.ts`에서 export하지 않는다. 소비자가 `primitiveVars.color.blue['500']`을 컴포넌트에 직접 사용하기 시작하면 semantic 계층이 형식적으로 전락하므로 노출 자체를 차단한다.
+
+```ts
+// index.ts
+export { vars } from './semantic/contract.css';   // 소비자용
+// primitiveVars는 export하지 않는다
+```

--- a/.github/decisions/token-naming-convention.md
+++ b/.github/decisions/token-naming-convention.md
@@ -1,0 +1,420 @@
+# SIDE v2 토큰 네이밍 컨벤션
+
+> 이 문서의 규칙은 `tokens/**/*.json` → codegen → `contract.css.ts` / `themes.css.ts` 파이프라인 전반에 적용된다.
+
+---
+
+## 1. 구분자 결정
+
+세 가지 표현 형식에 서로 다른 구분자를 사용하며, 변환 규칙은 고정이다.
+
+| 형식 | 구분자 | 예시 |
+|---|---|---|
+| **JSON 키** | `.` (점, 중첩 객체) | `color.blue.500` |
+| **VE vars 경로** | `.` (객체 접근) + `[]` (숫자 키) | `vars.color.blue[500]` |
+| **CSS 변수명** | `-` (하이픈) | `--side-color-blue-500` |
+
+### 변환 규칙
+
+```
+JSON key path: color.blue.500
+     ↓  join('-')
+CSS var name:  --side-color-blue-500
+     ↓  TS 객체 경로
+VE vars path:  vars.color.blue['500']
+```
+
+> **camelCase 금지**: CSS 변수명에는 하이픈만 사용한다. `--side-fontWeight-bold`가 아니라 `--side-font-weight-bold`.
+
+---
+
+## 2. Primitive Layer 네이밍
+
+### 2.1 색상 (color)
+
+```
+color.<hue>.<step>
+
+예시:
+  color.gray.50     → --side-color-gray-50
+  color.blue.500    → --side-color-blue-500
+  color.red.950     → --side-color-red-950
+  color.black       → --side-color-black
+  color.white       → --side-color-white
+```
+
+- `<hue>`: `gray | red | orange | yellow | green | teal | blue | cyan | purple | pink | black | white`
+- `<step>`: `50 | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 950`
+- `black`, `white`는 step 없이 단일 값
+- v1의 `gray50` 형태(camelCase + 숫자 붙이기)는 **폐기** — `.` 분리가 표준
+
+### 2.2 간격 (spacing)
+
+```
+spacing.<multiplier>
+
+예시:
+  spacing.1   → --side-spacing-1   (= 4px)
+  spacing.2   → --side-spacing-2   (= 8px)
+  spacing.4   → --side-spacing-4   (= 16px)
+```
+
+- 값은 `multiplier × 4px` 규칙으로 계산
+- v1의 키(0, 1, 2, 3, 4, 5, 6, 8, 10, 12, 16, 20, 24)를 유지하되 JSON에서 문자열 키로 저장 (`"1"`, `"2"`)
+- `spacing.0`은 `0px`, 토큰으로 정의하되 사용 빈도는 낮다
+
+### 2.3 둥근 모서리 (radius)
+
+```
+radius.<scale>
+
+예시:
+  radius.none   → --side-radius-none  (= 0)
+  radius.sm     → --side-radius-sm    (= 2px)
+  radius.md     → --side-radius-md    (= 4px)
+  radius.lg     → --side-radius-lg    (= 8px)
+  radius.xl     → --side-radius-xl    (= 12px)
+  radius.full   → --side-radius-full  (= 9999px)
+```
+
+- 스케일: `none | sm | md | lg | xl | full` (v1 동일 유지)
+
+### 2.4 타이포그래피 (typography)
+
+```
+typography.fontSize.<value>
+typography.fontWeight.<name>
+typography.lineHeight.<name>
+typography.fontFamily.<name>
+
+예시:
+  typography.fontSize.12    → --side-typography-font-size-12
+  typography.fontWeight.semiBold → --side-typography-font-weight-semi-bold
+  typography.lineHeight.regular  → --side-typography-line-height-regular
+```
+
+- `fontSize`: 숫자 값을 키로 사용 (`12 | 14 | 16 | 18 | 20 | 24 | 28 | 32 | 36 | 48`)
+- `fontWeight`: 시맨틱 이름 (`regular | medium | semiBold | bold`)
+- CSS 변수명 변환 시 camelCase → kebab-case (`semiBold` → `semi-bold`)
+
+### 2.5 그림자 (shadow)
+
+```
+shadow.<scale>
+
+예시:
+  shadow.none → --side-shadow-none
+  shadow.sm   → --side-shadow-sm
+  shadow.md   → --side-shadow-md
+  shadow.lg   → --side-shadow-lg
+  shadow.xl   → --side-shadow-xl
+  shadow.2xl  → --side-shadow-2xl
+```
+
+### 2.6 Z축 (z)
+
+```
+z.<role>
+
+예시:
+  z.hide      → --side-z-hide      (= -1)
+  z.base      → --side-z-base      (= 0)
+  z.dropdown  → --side-z-dropdown  (= 1000)
+  z.sticky    → --side-z-sticky    (= 1100)
+  z.modal     → --side-z-modal     (= 1400)
+  z.toast     → --side-z-toast     (= 1600)
+  z.tooltip   → --side-z-tooltip   (= 1700)
+```
+
+- v1 `zIndex` 키 이름을 `z`로 단축 (CSS var에서 `z-index`와 혼동 없음)
+
+### 2.7 애니메이션 (motion) — v2 신규
+
+```
+motion.duration.<name>
+motion.easing.<name>
+
+예시:
+  motion.duration.fast    → --side-motion-duration-fast    (= 100ms)
+  motion.duration.normal  → --side-motion-duration-normal  (= 200ms)
+  motion.duration.slow    → --side-motion-duration-slow    (= 300ms)
+  motion.duration.slower  → --side-motion-duration-slower  (= 500ms)
+
+  motion.easing.default   → --side-motion-easing-default   (= ease-in-out)
+  motion.easing.decelerate → --side-motion-easing-decelerate (= cubic-bezier(0,0,0.2,1))
+  motion.easing.accelerate → --side-motion-easing-accelerate (= cubic-bezier(0.4,0,1,1))
+  motion.easing.spring    → --side-motion-easing-spring    (= cubic-bezier(0.4,0,0.2,1))
+```
+
+> v1 감사에서 확인된 분산된 duration 값 (`0.15s, 0.2s, 0.3s, 1.2s, 1.5s, 2s`)을 `fast/normal/slow/slower` + 별도 animation 전용 키로 통합
+
+### 2.8 불투명도 (opacity)
+
+```
+opacity.<step>
+
+예시:
+  opacity.0    → --side-opacity-0    (= 0)
+  opacity.50   → --side-opacity-50   (= 0.5)
+  opacity.100  → --side-opacity-100  (= 1)
+```
+
+- step: `0 | 5 | 10 | 20 | 25 | 30 | 40 | 50 | 60 | 70 | 75 | 80 | 90 | 95 | 100`
+- 퍼센트 단위로 표현 (0.5 → `50`)
+
+### 2.9 테두리 (border)
+
+```
+border.width.<name>
+border.style.<name>
+
+예시:
+  border.width.none   → --side-border-width-none   (= 0)
+  border.width.thin   → --side-border-width-thin   (= 1px)
+  border.width.medium → --side-border-width-medium (= 2px)
+  border.width.thick  → --side-border-width-thick  (= 4px)
+```
+
+---
+
+## 3. Semantic Layer 네이밍
+
+### 3.1 색상 카테고리 (color)
+
+Semantic 색상은 **역할(role)** 기반으로 명명한다. Primitive에 있는 색상 이름을 Semantic에 쓰지 않는다.
+
+```
+color.<category>.<role>[.<variant>]
+
+카테고리:
+  text     — 텍스트
+  bg       — 배경
+  border   — 경계선
+  icon     — 아이콘
+  status   — 상태 (success/warning/error/info)
+  brand    — 테마 브랜드 색
+```
+
+**text**
+
+| 키 | 용도 |
+|---|---|
+| `color.text.primary` | 본문 기본 텍스트 |
+| `color.text.secondary` | 보조 텍스트, 설명 |
+| `color.text.tertiary` | 더 약한 힌트, placeholder |
+| `color.text.disabled` | 비활성 텍스트 |
+| `color.text.inverse` | 어두운 배경 위 밝은 텍스트 |
+| `color.text.link` | 링크 텍스트 |
+| `color.text.onAccent` | accent 배경 위 텍스트 |
+
+**bg**
+
+| 키 | 용도 |
+|---|---|
+| `color.bg.base` | 페이지 최상위 배경 |
+| `color.bg.surface` | 카드·패널 배경 |
+| `color.bg.overlay` | 모달·드로어 배경 |
+| `color.bg.subtle` | 구분선 없이 영역 구분할 때 |
+| `color.bg.accent` | 강조 배경 (brand primary) |
+| `color.bg.disabled` | 비활성 입력 배경 |
+
+**border**
+
+| 키 | 용도 |
+|---|---|
+| `color.border.default` | 일반 경계선 |
+| `color.border.subtle` | 미세 구분선 |
+| `color.border.focused` | 포커스 링 |
+| `color.border.error` | 에러 상태 경계선 |
+| `color.border.disabled` | 비활성 경계선 |
+
+**icon**
+
+| 키 | 용도 |
+|---|---|
+| `color.icon.default` | 기본 아이콘 |
+| `color.icon.secondary` | 보조 아이콘 |
+| `color.icon.disabled` | 비활성 아이콘 |
+| `color.icon.onAccent` | accent 배경 위 아이콘 |
+
+**status**
+
+| 키 | 용도 |
+|---|---|
+| `color.status.success` | 성공·완료 |
+| `color.status.warning` | 경고 |
+| `color.status.error` | 오류 (v1 `danger` → `error`로 변경) |
+| `color.status.info` | 정보 (v1 `positive` → `info`로 변경) |
+| `color.status.success.bg` | 성공 상태 배경 |
+| `color.status.error.bg` | 오류 상태 배경 |
+
+> v1 `danger` → `error`, `positive` → `info` 로 명칭 변경. 더 범용적이고 산업 표준에 가깝다.
+
+**brand**
+
+| 키 | 용도 |
+|---|---|
+| `color.brand.primary` | 테마 주 색상 (SIPE 기수별 상이) |
+| `color.brand.secondary` | 테마 보조 색상 |
+| `color.brand.gradient` | 그라디언트 (CSS value 전체) |
+| `color.brand.onPrimary` | primary 배경 위 텍스트 |
+
+### 3.2 상태 접미사 (state suffix)
+
+상태를 가지는 토큰은 마지막 세그먼트에 상태를 붙인다. 기본 상태(default)는 접미사를 생략한다.
+
+| 접미사 | 의미 | 예시 |
+|---|---|---|
+| _(없음)_ | 기본 상태 | `color.text.primary` |
+| `.hover` | 마우스 오버 | `color.bg.accent.hover` |
+| `.active` | 클릭/누름 | `color.bg.accent.active` |
+| `.disabled` | 비활성 | `color.text.disabled` |
+| `.focus` | 키보드 포커스 | `color.border.focused` (별도 카테고리로 분리) |
+| `.selected` | 선택됨 | `color.bg.surface.selected` |
+
+> `focus`는 `color.border.focused`처럼 `border` 카테고리 안에서 표현하는 것을 우선한다. 단독 `color.bg.xxx.focus`는 복합 상태에서만 사용.
+
+---
+
+## 4. 계열 접두사 규칙 요약
+
+| 카테고리 | Primitive 접두사 | Semantic 접두사 | VE vars 경로 |
+|---|---|---|---|
+| 색상 | `color.<hue>.<step>` | `color.<role>.*` | `vars.color.*` |
+| 간격 | `spacing.<n>` | — (Primitive 직접 사용) | `vars.spacing[n]` |
+| 둥근 모서리 | `radius.<scale>` | — (Primitive 직접 alias) | `vars.radius.*` |
+| 그림자 | `shadow.<scale>` | `shadow.<role>` | `vars.shadow.*` |
+| Z축 | `z.<role>` | — (Primitive 직접 사용) | `vars.z.*` |
+| 타이포그래피 | `typography.*` | — (Primitive 직접 사용) | `vars.typography.*` |
+| 애니메이션 | `motion.duration.*` / `motion.easing.*` | — | `vars.motion.*` |
+| 불투명도 | `opacity.<step>` | — | `vars.opacity[n]` |
+| 테두리 두께 | `border.width.*` | — | `vars.border.width.*` |
+
+Semantic이 없는 카테고리(spacing, radius 등)는 컴포넌트에서 Primitive vars를 직접 참조한다.
+
+---
+
+## 5. VE Contract 키 규칙
+
+### 숫자 키 처리
+
+TypeScript 객체 키는 숫자로 시작할 수 없다. 숫자 키는 **문자열 키**로 선언한다.
+
+```ts
+// 올바른 예
+const primitiveVars = createGlobalThemeContract({
+  color: {
+    gray: {
+      '50': null,   // 문자열 키
+      '500': null,
+      '950': null,
+    },
+  },
+  spacing: {
+    '1': null,
+    '4': null,
+  },
+});
+
+// 접근 시
+vars.color.gray['500']    // bracket notation
+vars.spacing['4']
+```
+
+### camelCase → kebab-case 변환
+
+Contract 매핑 함수가 자동으로 변환한다:
+
+```ts
+createGlobalThemeContract(
+  { typography: { fontWeight: { semiBold: null } } },
+  (_, path) => `side-${path.map(toKebab).join('-')}`,
+  // → --side-typography-font-weight-semi-bold
+);
+
+function toKebab(str: string) {
+  return str.replace(/([A-Z])/g, '-$1').toLowerCase();
+}
+```
+
+---
+
+## 6. JSON 파일 키 예시
+
+### `tokens/primitive/color.json`
+
+```json
+{
+  "color": {
+    "black": { "value": "#131518", "type": "color" },
+    "white": { "value": "#ffffff", "type": "color" },
+    "gray": {
+      "50":  { "value": "#fafafa", "type": "color" },
+      "500": { "value": "#71717a", "type": "color" },
+      "950": { "value": "#111111", "type": "color" }
+    },
+    "blue": {
+      "500": { "value": "#3b82f6", "type": "color" }
+    }
+  }
+}
+```
+
+### `tokens/semantic/light/color.json`
+
+```json
+{
+  "color": {
+    "text": {
+      "primary":   { "value": "{color.gray.950}", "type": "color" },
+      "secondary": { "value": "{color.gray.600}", "type": "color" },
+      "disabled":  { "value": "{color.gray.400}", "type": "color" },
+      "inverse":   { "value": "{color.white}",    "type": "color" }
+    },
+    "bg": {
+      "base":    { "value": "{color.gray.50}",  "type": "color" },
+      "surface": { "value": "{color.white}",    "type": "color" }
+    },
+    "status": {
+      "success": { "value": "{color.green.500}", "type": "color" },
+      "warning": { "value": "{color.orange.400}", "type": "color" },
+      "error":   { "value": "{color.red.500}",   "type": "color" },
+      "info":    { "value": "{color.blue.400}",  "type": "color" }
+    }
+  }
+}
+```
+
+### `tokens/semantic/dark/color.json`
+
+```json
+{
+  "color": {
+    "text": {
+      "primary":   { "value": "{color.gray.50}",  "type": "color" },
+      "secondary": { "value": "{color.gray.400}", "type": "color" },
+      "disabled":  { "value": "{color.gray.600}", "type": "color" },
+      "inverse":   { "value": "{color.gray.950}", "type": "color" }
+    },
+    "bg": {
+      "base":    { "value": "{color.gray.950}", "type": "color" },
+      "surface": { "value": "{color.gray.900}", "type": "color" }
+    }
+  }
+}
+```
+
+---
+
+## 7. 금지 패턴
+
+| 금지 패턴 | 이유 | 대안 |
+|---|---|---|
+| Semantic에 hex 직접 사용 | 다크모드 전환 불가 | Primitive alias `{color.gray.950}` |
+| Primitive에 의미론 이름 | 역할이 고정되어 확장 어려움 | `color.primary` → `color.brand.primary` (Semantic에) |
+| 컴포넌트에서 `primitiveVars` import | Primitive는 내부 구현 세부사항 | `vars` (Semantic) 만 import |
+| CSS var에 camelCase | CSS 관례 위반 | `--side-font-weight-semi-bold` |
+| `danger`, `positive` 이름 | 비표준, 혼동 유발 | `error`, `info` |
+| `vars.spacing.xs` 같은 t-shirt size | 범위가 불명확, 확장 어려움 | `vars.spacing['2']` (4px 단위 scale) |
+
+> v1의 `vars.spacing.xs/sm/md/lg/xl` 패턴은 **v2에서 폐기**. 숫자 스케일이 컴포넌트 조합 시 훨씬 예측 가능하다.


### PR DESCRIPTION
## Summary                                                                           
  - Primitive / Semantic 2계층 토큰 아키텍처 설계 문서 추가 (`token-architecture.md`)
  - 토큰 네이밍 컨벤션 문서 추가 (`token-naming-convention.md`)
                                                                                                                                                
## 주요 설계 결정
  - 2 layer 구조: Primitive(원시값 팔레트), Semantic(의미 기반 alias)
  - Primitive foundation 범위: Colors / Spacing / Typography / Radius
  - 다크 모드 기본값: `:root`에 dark values 주입, 시스템 라이트모드는 `@media (prefers-color-scheme: light)` + `[data-mode="light"]` 명시로 대응

Closes #219