### PR TITLE
feat(image): add image component

### DIFF
--- a/.changeset/tidy-planets-divide.md
+++ b/.changeset/tidy-planets-divide.md
@@ -1,0 +1,6 @@
+---
+"@sipe-team/image": minor
+"@sipe-team/side": minor
+---
+
+Add @sipe-team/image and refine Image after PR review (styles, ref, state, exports, docs)

--- a/.changeset/tidy-planets-divide.md
+++ b/.changeset/tidy-planets-divide.md
@@ -3,4 +3,4 @@
 "@sipe-team/side": minor
 ---
 
-Add @sipe-team/image and refine Image after PR review (styles, ref, state, exports, docs)
+Add @sipe-team/image and refine after PR review. Forward onLoad callbacks and add radius token prop.

--- a/packages/image/global.d.ts
+++ b/packages/image/global.d.ts
@@ -1,0 +1,1 @@
+declare module '*.module.css';

--- a/packages/image/global.d.ts
+++ b/packages/image/global.d.ts
@@ -1,1 +1,0 @@
-declare module '*.module.css';

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -20,6 +20,7 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
+    "@sipe-team/tokens": "workspace:*",
     "clsx": "catalog:"
   },
   "devDependencies": {

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@sipe-team/image",
+  "description": "Image for Sipe Design System",
+  "version": "0.0.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sipe-team/side"
+  },
+  "type": "module",
+  "exports": "./src/index.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "lint": "pnpm exec biome lint",
+    "test": "vitest",
+    "typecheck": "tsc",
+    "prepack": "pnpm run build"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
+    "@types/react": "catalog:react",
+    "happy-dom": "catalog:",
+    "react": "catalog:react",
+    "react-dom": "catalog:react",
+    "tsup": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "react": ">= 18",
+    "react-dom": ">= 18"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://npm.pkg.github.com",
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        },
+        "require": {
+          "types": "./dist/index.d.cts",
+          "default": "./dist/index.cjs"
+        }
+      },
+      "./styles.css": "./dist/index.css"
+    }
+  },
+  "sideEffects": [
+    "**/*.css"
+  ]
+}

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -19,10 +19,15 @@
     "typecheck": "tsc",
     "prepack": "pnpm run build"
   },
+  "dependencies": {
+    "clsx": "catalog:"
+  },
   "devDependencies": {
     "@testing-library/jest-dom": "catalog:",
     "@testing-library/react": "catalog:",
     "@types/react": "catalog:react",
+    "@vanilla-extract/css": "catalog:",
+    "@vanilla-extract/dynamic": "catalog:",
     "happy-dom": "catalog:",
     "react": "catalog:react",
     "react-dom": "catalog:react",

--- a/packages/image/src/Image.css.ts
+++ b/packages/image/src/Image.css.ts
@@ -1,0 +1,26 @@
+import { createVar, fallbackVar, style, styleVariants } from '@vanilla-extract/css';
+
+export const widthVar = createVar();
+export const heightVar = createVar();
+
+export const sized = style({
+  width: fallbackVar(widthVar, 'auto'),
+  height: fallbackVar(heightVar, 'auto'),
+});
+
+export const fit = styleVariants({
+  contain: { objectFit: 'contain' },
+  cover: { objectFit: 'cover' },
+  fill: { objectFit: 'fill' },
+});
+
+export const fill = style({
+  position: 'absolute',
+  inset: 0,
+  width: '100%',
+  height: '100%',
+});
+
+export const hidden = style({
+  visibility: 'hidden',
+});

--- a/packages/image/src/Image.css.ts
+++ b/packages/image/src/Image.css.ts
@@ -1,3 +1,5 @@
+import { radius as radiusToken } from '@sipe-team/tokens';
+
 import { createVar, fallbackVar, style, styleVariants } from '@vanilla-extract/css';
 
 export const widthVar = createVar();
@@ -12,6 +14,15 @@ export const fit = styleVariants({
   contain: { objectFit: 'contain' },
   cover: { objectFit: 'cover' },
   fill: { objectFit: 'fill' },
+});
+
+export const radius = styleVariants({
+  none: { borderRadius: radiusToken.none },
+  sm: { borderRadius: radiusToken.sm },
+  md: { borderRadius: radiusToken.md },
+  lg: { borderRadius: radiusToken.lg },
+  xl: { borderRadius: radiusToken.xl },
+  full: { borderRadius: radiusToken.full },
 });
 
 export const fill = style({

--- a/packages/image/src/Image.css.ts
+++ b/packages/image/src/Image.css.ts
@@ -1,4 +1,4 @@
-import { radius as radiusToken } from '@sipe-team/tokens';
+import { vars } from '@sipe-team/tokens';
 
 import { createVar, fallbackVar, style, styleVariants } from '@vanilla-extract/css';
 
@@ -17,12 +17,12 @@ export const fit = styleVariants({
 });
 
 export const radius = styleVariants({
-  none: { borderRadius: radiusToken.none },
-  sm: { borderRadius: radiusToken.sm },
-  md: { borderRadius: radiusToken.md },
-  lg: { borderRadius: radiusToken.lg },
-  xl: { borderRadius: radiusToken.xl },
-  full: { borderRadius: radiusToken.full },
+  none: { borderRadius: vars.radius.none },
+  sm: { borderRadius: vars.radius.sm },
+  md: { borderRadius: vars.radius.md },
+  lg: { borderRadius: vars.radius.lg },
+  xl: { borderRadius: vars.radius.xl },
+  full: { borderRadius: vars.radius.full },
 });
 
 export const fill = style({

--- a/packages/image/src/Image.css.ts
+++ b/packages/image/src/Image.css.ts
@@ -17,12 +17,12 @@ export const fit = styleVariants({
 });
 
 export const radius = styleVariants({
-  none: { borderRadius: vars.radius.none },
-  sm: { borderRadius: vars.radius.sm },
-  md: { borderRadius: vars.radius.md },
-  lg: { borderRadius: vars.radius.lg },
-  xl: { borderRadius: vars.radius.xl },
-  full: { borderRadius: vars.radius.full },
+  none: { borderRadius: 0 },
+  sm: { borderRadius: vars.radius.component.sm },
+  md: { borderRadius: vars.radius.component.md },
+  lg: { borderRadius: vars.radius.component.lg },
+  xl: { borderRadius: vars.radius.component.xl },
+  full: { borderRadius: vars.radius.component.full },
 });
 
 export const fill = style({

--- a/packages/image/src/Image.stories.tsx
+++ b/packages/image/src/Image.stories.tsx
@@ -1,0 +1,176 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Image } from './Image';
+
+const meta: Meta<typeof Image> = {
+  title: 'Components/Image',
+  component: Image,
+  parameters: {
+    backgrounds: {
+      default: 'light',
+    },
+  },
+  args: {
+    src: 'https://picsum.photos/400/300',
+    alt: '예시 이미지',
+    width: 400,
+    height: 300,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Image>;
+
+export const Basic: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '기본 이미지 렌더링입니다. 기본 크기와 기본 fit 동작을 확인할 수 있습니다.',
+      },
+    },
+  },
+};
+
+export const Fallbacks: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'fallbackSrc가 있을 때와 없을 때 동작을 한 번에 비교합니다.',
+      },
+    },
+  },
+  render: (args) => (
+    <div style={{ display: 'flex', gap: 12 }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <Image
+          {...args}
+          alt="fallback with src"
+          src="https://invalid-url.com/broken.jpg"
+          fallbackSrc="https://dummyimage.com/400x300/e5e7eb/111827&text=FALLBACK"
+        />
+        <span style={{ fontSize: 12, color: '#71717a' }}>with fallbackSrc</span>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <div
+          style={{
+            width: 400,
+            height: 300,
+            border: '1px dashed #d4d4d8',
+            borderRadius: 8,
+            background: 'repeating-linear-gradient(45deg, #fafafa, #fafafa 10px, #f4f4f5 10px, #f4f4f5 20px)',
+          }}
+        >
+          <Image {...args} alt="error without fallback" src="https://invalid-url.com/broken.jpg" />
+        </div>
+        <span style={{ fontSize: 12, color: '#71717a' }}>without fallbackSrc</span>
+      </div>
+    </div>
+  ),
+  args: {
+    width: 400,
+    height: 300,
+  },
+};
+
+export const WithPlaceholder: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '로딩 중 placeholder 확인은 DevTools에서 네트워크를 Slow 3G로 설정 후 새로고침하세요.',
+      },
+    },
+  },
+  args: {
+    src: 'https://picsum.photos/400/300',
+    alt: 'placeholder 예시',
+    placeholder: (
+      <div
+        style={{
+          width: 400,
+          height: 300,
+          background: '#e0e0e0',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        로딩 중...
+      </div>
+    ),
+  },
+};
+
+export const WithFill: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'fill 사용 예시입니다. 부모 컨테이너에 `position: relative`, `width: 400`, `height: 300`이 필요합니다.',
+      },
+    },
+  },
+  render: (args) => (
+    <div style={{ position: 'relative', width: 400, height: 300 }}>
+      <Image {...args} fill />
+    </div>
+  ),
+  args: {
+    src: 'https://picsum.photos/400/300',
+  },
+};
+
+export const Fits: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'fit 옵션(`contain`, `cover`)을 같은 크기 박스에서 비교하는 예시입니다.',
+      },
+    },
+  },
+  render: (args) => (
+    <div style={{ display: 'flex', gap: 12 }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <Image {...args} fit="contain" alt="fit contain" />
+        <span style={{ fontSize: 12, color: '#71717a' }}>fit: contain</span>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <Image {...args} fit="cover" alt="fit cover" />
+        <span style={{ fontSize: 12, color: '#71717a' }}>fit: cover</span>
+      </div>
+    </div>
+  ),
+  args: {
+    src: 'https://picsum.photos/600/200',
+    width: 300,
+    height: 300,
+  },
+};
+
+export const ResponsiveWidth: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'width를 string(100%)으로 전달했을 때 부모 너비를 따라 반응형으로 동작하는 예시입니다.',
+      },
+    },
+  },
+  render: (args) => (
+    <div
+      style={{
+        width: '100%',
+        maxWidth: 500,
+        minWidth: 220,
+        resize: 'horizontal',
+        overflow: 'auto',
+        border: '1px solid #e4e4e7',
+        padding: 8,
+      }}
+    >
+      <Image {...args} />
+    </div>
+  ),
+  args: {
+    src: 'https://picsum.photos/400/300',
+    width: '100%',
+    height: 300,
+  },
+};

--- a/packages/image/src/Image.stories.tsx
+++ b/packages/image/src/Image.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { Image } from './Image';
+import { Image, ImageRadius } from './Image';
 
 const meta: Meta<typeof Image> = {
   title: 'Components/Image',
@@ -143,6 +143,26 @@ export const Fits: Story = {
     width: 300,
     height: 300,
   },
+};
+
+export const Radiuses: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'radius 토큰(`none` ~ `full`)을 적용한 예시입니다.',
+      },
+    },
+  },
+  render: (args) => (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12 }}>
+      {Object.values(ImageRadius).map((radius) => (
+        <div key={radius} style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <Image {...args} radius={radius} alt={`radius ${radius}`} width={120} height={120} />
+          <span style={{ fontSize: 12, color: '#71717a' }}>radius: {radius}</span>
+        </div>
+      ))}
+    </div>
+  ),
 };
 
 export const ResponsiveWidth: Story = {

--- a/packages/image/src/Image.test.tsx
+++ b/packages/image/src/Image.test.tsx
@@ -154,6 +154,34 @@ describe('Image', () => {
     expect(img).toHaveAttribute('loading', 'lazy');
   });
 
+  it('always calls user onLoad callback', () => {
+    const onLoad = vi.fn();
+    render(<Image src="https://picsum.photos/400/300" alt="onLoad test" onLoad={onLoad} />);
+
+    const img = screen.getByRole('img', { name: 'onLoad test' });
+    fireEvent.load(img);
+
+    expect(onLoad).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls user onLoad callback when fallback image loads', () => {
+    const onLoad = vi.fn();
+    render(
+      <Image
+        src="https://invalid-url.com/broken.jpg"
+        fallbackSrc="https://dummyimage.com/400x300/e5e7eb/111827&text=FALLBACK"
+        alt="fallback onLoad test"
+        onLoad={onLoad}
+      />,
+    );
+
+    const img = screen.getByRole('img', { name: 'fallback onLoad test' });
+    fireEvent.error(img);
+    fireEvent.load(img);
+
+    expect(onLoad).toHaveBeenCalledTimes(1);
+  });
+
   it('always calls user onError callback', () => {
     const onError = vi.fn();
     render(<Image src="https://invalid-url.com/broken.jpg" alt="onError test" onError={onError} />);

--- a/packages/image/src/Image.test.tsx
+++ b/packages/image/src/Image.test.tsx
@@ -1,3 +1,5 @@
+import { createRef } from 'react';
+
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -12,6 +14,27 @@ describe('Image', () => {
     expect(img).toHaveAttribute('src', 'https://picsum.photos/400/300');
   });
 
+  it('updates img src when the Image src prop changes after mount', () => {
+    const firstSrc = 'https://picsum.photos/id/10/200/300';
+    const secondSrc = 'https://picsum.photos/id/20/200/300';
+
+    const { rerender } = render(<Image src={firstSrc} alt="gallery" />);
+    const img = screen.getByRole('img', { name: 'gallery' });
+    expect(img).toHaveAttribute('src', firstSrc);
+
+    rerender(<Image src={secondSrc} alt="gallery" />);
+    expect(img).toHaveAttribute('src', secondSrc);
+  });
+
+  it('forwards ref to the img element', () => {
+    const ref = createRef<HTMLImageElement>();
+    render(<Image ref={ref} src="https://picsum.photos/400/300" alt="ref test" />);
+
+    expect(ref.current).toBeInstanceOf(HTMLImageElement);
+    expect(ref.current?.tagName).toBe('IMG');
+    expect(ref.current).toHaveAttribute('alt', 'ref test');
+  });
+
   it('applies width and height styles for number and string values', () => {
     render(<Image src="https://picsum.photos/400/300" alt="size test" width={320} height="50%" />);
 
@@ -20,6 +43,20 @@ describe('Image', () => {
       width: '320px',
       height: '50%',
     });
+  });
+
+  it('applies width only; height falls back to auto (CSS variables + sized)', () => {
+    render(<Image src="https://picsum.photos/400/300" alt="width only" width={200} />);
+
+    const img = screen.getByRole('img', { name: 'width only' });
+    expect(img).toHaveStyle({ width: '200px', height: 'auto' });
+  });
+
+  it('applies height only; width falls back to auto (CSS variables + sized)', () => {
+    render(<Image src="https://picsum.photos/400/300" alt="height only" height="120px" />);
+
+    const img = screen.getByRole('img', { name: 'height only' });
+    expect(img).toHaveStyle({ width: 'auto', height: '120px' });
   });
 
   it('switches to fallbackSrc once when image load fails', () => {
@@ -78,6 +115,36 @@ describe('Image', () => {
       width: '100%',
       height: '100%',
     });
+  });
+
+  it('prefers fill layout over width prop (no sized / no pixel width from props)', () => {
+    render(
+      <div style={{ position: 'relative', width: 400, height: 300 }}>
+        <Image src="https://picsum.photos/400/300" alt="fill and width" fill width={200} />
+      </div>,
+    );
+
+    const img = screen.getByRole('img', { name: 'fill and width' });
+    expect(img).toHaveStyle({
+      position: 'absolute',
+      width: '100%',
+      height: '100%',
+    });
+    expect(img).not.toHaveStyle({ width: '200px' });
+  });
+
+  it('applies object-fit from fit prop', () => {
+    render(
+      <Image src="https://picsum.photos/400/300" alt="object-fit contain" width={100} height={100} fit="contain" />,
+    );
+
+    expect(screen.getByRole('img', { name: 'object-fit contain' })).toHaveStyle({ objectFit: 'contain' });
+  });
+
+  it('applies object-fit fill variant from fit prop', () => {
+    render(<Image src="https://picsum.photos/400/300" alt="object-fit fill" width={100} height={100} fit="fill" />);
+
+    expect(screen.getByRole('img', { name: 'object-fit fill' })).toHaveStyle({ objectFit: 'fill' });
   });
 
   it('uses lazy loading by default', () => {

--- a/packages/image/src/Image.test.tsx
+++ b/packages/image/src/Image.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Image } from './Image';
+
+describe('Image', () => {
+  it('renders with required src and alt props', () => {
+    render(<Image src="https://picsum.photos/400/300" alt="sample image" />);
+
+    const img = screen.getByRole('img', { name: 'sample image' });
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', 'https://picsum.photos/400/300');
+  });
+
+  it('applies width and height styles for number and string values', () => {
+    render(<Image src="https://picsum.photos/400/300" alt="size test" width={320} height="50%" />);
+
+    const img = screen.getByRole('img', { name: 'size test' });
+    expect(img).toHaveStyle({
+      width: '320px',
+      height: '50%',
+    });
+  });
+
+  it('switches to fallbackSrc once when image load fails', () => {
+    render(
+      <Image
+        src="https://invalid-url.com/broken.jpg"
+        fallbackSrc="https://dummyimage.com/400x300/e5e7eb/111827&text=FALLBACK"
+        alt="fallback test"
+      />,
+    );
+
+    const img = screen.getByRole('img', { name: 'fallback test' });
+    fireEvent.error(img);
+
+    expect(img).toHaveAttribute('src', 'https://dummyimage.com/400x300/e5e7eb/111827&text=FALLBACK');
+  });
+
+  it('moves to error state and hides image when fallback is unavailable', () => {
+    render(<Image src="https://invalid-url.com/broken.jpg" alt="error test" width={400} height={300} />);
+
+    const img = screen.getByRole('img', { name: 'error test' });
+    fireEvent.error(img);
+
+    expect(img).toHaveStyle({ visibility: 'hidden' });
+  });
+
+  it('shows placeholder while loading and hides it after load', () => {
+    render(
+      <Image
+        src="https://picsum.photos/400/300"
+        alt="placeholder test"
+        placeholder={
+          <div data-testid="placeholder" style={{ width: 400, height: 300 }}>
+            loading...
+          </div>
+        }
+      />,
+    );
+
+    const img = screen.getByAltText('placeholder test');
+    expect(screen.getByTestId('placeholder')).toBeInTheDocument();
+    expect(img).toHaveStyle({ visibility: 'hidden' });
+
+    fireEvent.load(img);
+
+    expect(screen.queryByTestId('placeholder')).not.toBeInTheDocument();
+    expect(img.style.visibility).toBe('');
+  });
+
+  it('applies fill styles when fill is true', () => {
+    render(<Image src="https://picsum.photos/400/300" alt="fill test" fill />);
+
+    const img = screen.getByRole('img', { name: 'fill test' });
+    expect(img).toHaveStyle({
+      position: 'absolute',
+      width: '100%',
+      height: '100%',
+    });
+  });
+
+  it('uses lazy loading by default', () => {
+    render(<Image src="https://picsum.photos/400/300" alt="loading attr test" />);
+
+    const img = screen.getByRole('img', { name: 'loading attr test' });
+    expect(img).toHaveAttribute('loading', 'lazy');
+  });
+
+  it('always calls user onError callback', () => {
+    const onError = vi.fn();
+    render(<Image src="https://invalid-url.com/broken.jpg" alt="onError test" onError={onError} />);
+
+    const img = screen.getByRole('img', { name: 'onError test' });
+    fireEvent.error(img);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/image/src/Image.test.tsx
+++ b/packages/image/src/Image.test.tsx
@@ -74,6 +74,49 @@ describe('Image', () => {
     expect(img).toHaveAttribute('src', 'https://dummyimage.com/400x300/e5e7eb/111827&text=FALLBACK');
   });
 
+  it('moves to error state and hides image when both src and fallbackSrc fail', () => {
+    render(<Image src="이미지없음" fallbackSrc="이것도없음" alt="무한실패" />);
+
+    const img = screen.getByRole('img', { name: '무한실패' });
+    fireEvent.error(img);
+
+    expect(img).toHaveAttribute('src', '이것도없음');
+
+    fireEvent.error(img);
+
+    expect(img).toHaveAttribute('src', '이것도없음');
+    expect(img).toHaveStyle({ visibility: 'hidden' });
+  });
+
+  it('does not retry fallback after fallbackSrc fails once', () => {
+    const onError = vi.fn();
+    render(
+      <Image
+        src="https://invalid-url.com/broken.jpg"
+        fallbackSrc="https://invalid-url.com/broken-fallback.jpg"
+        alt="no infinite fallback"
+        onError={onError}
+      />,
+    );
+
+    const img = screen.getByRole('img', { name: 'no infinite fallback' });
+    fireEvent.error(img);
+
+    expect(img).toHaveAttribute('src', 'https://invalid-url.com/broken-fallback.jpg');
+    expect(onError).toHaveBeenCalledTimes(1);
+
+    fireEvent.error(img);
+
+    expect(img).toHaveAttribute('src', 'https://invalid-url.com/broken-fallback.jpg');
+    expect(onError).toHaveBeenCalledTimes(2);
+    expect(img).toHaveStyle({ visibility: 'hidden' });
+
+    fireEvent.error(img);
+
+    expect(img).toHaveAttribute('src', 'https://invalid-url.com/broken-fallback.jpg');
+    expect(onError).toHaveBeenCalledTimes(3);
+  });
+
   it('moves to error state and hides image when fallback is unavailable', () => {
     render(<Image src="https://invalid-url.com/broken.jpg" alt="error test" width={400} height={300} />);
 

--- a/packages/image/src/Image.tsx
+++ b/packages/image/src/Image.tsx
@@ -1,12 +1,17 @@
-import type { ComponentPropsWithoutRef, CSSProperties, ReactNode } from 'react';
+import { type ComponentPropsWithoutRef, type ForwardedRef, forwardRef, type ReactNode } from 'react';
+
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+
+import { clsx as cx } from 'clsx';
 
 import { useImageStatus } from './hooks/useImageStatus';
+import * as styles from './Image.css';
 
 type ImageSize = number | string;
 type ImageFit = 'contain' | 'cover' | 'fill';
 
 export interface ImageProps
-  extends Omit<ComponentPropsWithoutRef<'img'>, 'src' | 'alt' | 'width' | 'height' | 'onLoad'> {
+  extends Omit<ComponentPropsWithoutRef<'img'>, 'src' | 'alt' | 'width' | 'height' | 'onLoad' | 'onError'> {
   src: string;
   alt: string;
   width?: ImageSize;
@@ -15,58 +20,68 @@ export interface ImageProps
   fill?: boolean;
   fallbackSrc?: string;
   placeholder?: ReactNode;
+  onError?: ComponentPropsWithoutRef<'img'>['onError'];
 }
 
-export function Image({
-  src,
-  alt,
-  width,
-  height,
-  fit = 'cover',
-  fill = false,
-  fallbackSrc,
-  placeholder,
-  loading = 'lazy',
-  onError,
-  style,
-  ...props
-}: ImageProps) {
+export const Image = forwardRef(function Image(
+  {
+    src,
+    alt,
+    width,
+    height,
+    fit = 'cover',
+    fill = false,
+    fallbackSrc,
+    placeholder,
+    loading = 'lazy',
+    onError,
+    className: _className,
+    style,
+    ...props
+  }: ImageProps,
+  ref: ForwardedRef<HTMLImageElement>,
+) {
   const { status, imgSrc, handleLoad, handleError } = useImageStatus({
     src,
     ...(fallbackSrc ? { fallbackSrc } : {}),
     ...(onError ? { onError } : {}),
   });
 
-  const showPlaceholder = status === 'loading' && placeholder !== undefined;
+  const showPlaceholder = (status === 'loading' || status === 'fallback') && placeholder !== undefined;
   const isHidden = showPlaceholder || status === 'error';
 
-  const sizeStyle: CSSProperties = {
-    width: typeof width === 'number' ? `${width}px` : width,
-    height: typeof height === 'number' ? `${height}px` : height,
-    objectFit: fit,
-  };
-
-  const fillStyle: CSSProperties = fill
-    ? {
-        position: 'absolute',
-        inset: 0,
-        width: '100%',
-        height: '100%',
-      }
-    : {};
+  const useSized = !fill && (width !== undefined || height !== undefined);
+  const dimensionStyle =
+    useSized &&
+    assignInlineVars({
+      ...(width !== undefined && {
+        [styles.widthVar]: typeof width === 'number' ? `${width}px` : width,
+      }),
+      ...(height !== undefined && {
+        [styles.heightVar]: typeof height === 'number' ? `${height}px` : height,
+      }),
+    });
 
   return (
     <>
       {showPlaceholder ? placeholder : null}
       <img
-        {...props}
+        ref={ref}
+        className={cx(
+          styles.fit[fit],
+          fill && styles.fill,
+          useSized && styles.sized,
+          isHidden && styles.hidden,
+          _className,
+        )}
         src={imgSrc}
         alt={alt}
         loading={loading}
         onLoad={handleLoad}
         onError={handleError}
-        style={{ ...sizeStyle, ...fillStyle, visibility: isHidden ? 'hidden' : undefined, ...style }}
+        style={{ ...(dimensionStyle || {}), ...style }}
+        {...props}
       />
     </>
   );
-}
+});

--- a/packages/image/src/Image.tsx
+++ b/packages/image/src/Image.tsx
@@ -1,0 +1,72 @@
+import type { ComponentPropsWithoutRef, CSSProperties, ReactNode } from 'react';
+
+import { useImageStatus } from './hooks/useImageStatus';
+
+type ImageSize = number | string;
+type ImageFit = 'contain' | 'cover' | 'fill';
+
+export interface ImageProps
+  extends Omit<ComponentPropsWithoutRef<'img'>, 'src' | 'alt' | 'width' | 'height' | 'onLoad'> {
+  src: string;
+  alt: string;
+  width?: ImageSize;
+  height?: ImageSize;
+  fit?: ImageFit;
+  fill?: boolean;
+  fallbackSrc?: string;
+  placeholder?: ReactNode;
+}
+
+export function Image({
+  src,
+  alt,
+  width,
+  height,
+  fit = 'cover',
+  fill = false,
+  fallbackSrc,
+  placeholder,
+  loading = 'lazy',
+  onError,
+  style,
+  ...props
+}: ImageProps) {
+  const { status, imgSrc, handleLoad, handleError } = useImageStatus({
+    src,
+    ...(fallbackSrc ? { fallbackSrc } : {}),
+    ...(onError ? { onError } : {}),
+  });
+
+  const showPlaceholder = status === 'loading' && placeholder !== undefined;
+  const isHidden = showPlaceholder || status === 'error';
+
+  const sizeStyle: CSSProperties = {
+    width: typeof width === 'number' ? `${width}px` : width,
+    height: typeof height === 'number' ? `${height}px` : height,
+    objectFit: fit,
+  };
+
+  const fillStyle: CSSProperties = fill
+    ? {
+        position: 'absolute',
+        inset: 0,
+        width: '100%',
+        height: '100%',
+      }
+    : {};
+
+  return (
+    <>
+      {showPlaceholder ? placeholder : null}
+      <img
+        {...props}
+        src={imgSrc}
+        alt={alt}
+        loading={loading}
+        onLoad={handleLoad}
+        onError={handleError}
+        style={{ ...sizeStyle, ...fillStyle, visibility: isHidden ? 'hidden' : undefined, ...style }}
+      />
+    </>
+  );
+}

--- a/packages/image/src/Image.tsx
+++ b/packages/image/src/Image.tsx
@@ -20,6 +20,7 @@ export interface ImageProps
   fill?: boolean;
   fallbackSrc?: string;
   placeholder?: ReactNode;
+  onLoad?: ComponentPropsWithoutRef<'img'>['onLoad'];
   onError?: ComponentPropsWithoutRef<'img'>['onError'];
 }
 
@@ -34,6 +35,7 @@ export const Image = forwardRef(function Image(
     fallbackSrc,
     placeholder,
     loading = 'lazy',
+    onLoad,
     onError,
     className: _className,
     style,
@@ -44,6 +46,7 @@ export const Image = forwardRef(function Image(
   const { status, imgSrc, handleLoad, handleError } = useImageStatus({
     src,
     ...(fallbackSrc ? { fallbackSrc } : {}),
+    ...(onLoad ? { onLoad } : {}),
     ...(onError ? { onError } : {}),
   });
 

--- a/packages/image/src/Image.tsx
+++ b/packages/image/src/Image.tsx
@@ -10,6 +10,16 @@ import * as styles from './Image.css';
 type ImageSize = number | string;
 type ImageFit = 'contain' | 'cover' | 'fill';
 
+export const ImageRadius = {
+  none: 'none',
+  sm: 'sm',
+  md: 'md',
+  lg: 'lg',
+  xl: 'xl',
+  full: 'full',
+} as const;
+export type ImageRadius = (typeof ImageRadius)[keyof typeof ImageRadius];
+
 export interface ImageProps
   extends Omit<ComponentPropsWithoutRef<'img'>, 'src' | 'alt' | 'width' | 'height' | 'onLoad' | 'onError'> {
   src: string;
@@ -18,6 +28,7 @@ export interface ImageProps
   height?: ImageSize;
   fit?: ImageFit;
   fill?: boolean;
+  radius?: ImageRadius;
   fallbackSrc?: string;
   placeholder?: ReactNode;
   onLoad?: ComponentPropsWithoutRef<'img'>['onLoad'];
@@ -32,6 +43,7 @@ export const Image = forwardRef(function Image(
     height,
     fit = 'cover',
     fill = false,
+    radius = ImageRadius.none,
     fallbackSrc,
     placeholder,
     loading = 'lazy',
@@ -72,6 +84,7 @@ export const Image = forwardRef(function Image(
         ref={ref}
         className={cx(
           styles.fit[fit],
+          styles.radius[radius],
           fill && styles.fill,
           useSized && styles.sized,
           isHidden && styles.hidden,

--- a/packages/image/src/Image.tsx
+++ b/packages/image/src/Image.tsx
@@ -49,7 +49,7 @@ export const Image = forwardRef(function Image(
     loading = 'lazy',
     onLoad,
     onError,
-    className: _className,
+    className,
     style,
     ...props
   }: ImageProps,
@@ -88,7 +88,7 @@ export const Image = forwardRef(function Image(
           fill && styles.fill,
           useSized && styles.sized,
           isHidden && styles.hidden,
-          _className,
+          className,
         )}
         src={imgSrc}
         alt={alt}

--- a/packages/image/src/hooks/useImageStatus.ts
+++ b/packages/image/src/hooks/useImageStatus.ts
@@ -1,4 +1,4 @@
-import { type SyntheticEvent, useCallback, useState } from 'react';
+import { type SyntheticEvent, useCallback, useEffect, useState } from 'react';
 
 export type ImageStatus = 'loading' | 'normal' | 'fallback' | 'error';
 
@@ -22,7 +22,11 @@ export function useImageStatus({
 }: UseImageStatusParams): UseImageStatusResult {
   const [status, setStatus] = useState<ImageStatus>('loading');
   const [imgSrc, setImgSrc] = useState(src);
-  const [hasTriedFallback, setHasTriedFallback] = useState(false);
+
+  useEffect(() => {
+    setImgSrc(src);
+    setStatus('loading');
+  }, [src]);
 
   const handleLoad = useCallback((_event: SyntheticEvent<HTMLImageElement>) => {
     setStatus('normal');
@@ -32,16 +36,15 @@ export function useImageStatus({
     (event: SyntheticEvent<HTMLImageElement>) => {
       onErrorFromProps?.(event);
 
-      if (!hasTriedFallback && fallbackSrc) {
+      if (status !== 'fallback' && fallbackSrc) {
         setImgSrc(fallbackSrc);
-        setHasTriedFallback(true);
-        setStatus('loading');
+        setStatus('fallback');
         return;
       }
 
       setStatus('error');
     },
-    [fallbackSrc, hasTriedFallback, onErrorFromProps],
+    [fallbackSrc, onErrorFromProps, status],
   );
 
   return {

--- a/packages/image/src/hooks/useImageStatus.ts
+++ b/packages/image/src/hooks/useImageStatus.ts
@@ -5,6 +5,7 @@ export type ImageStatus = 'loading' | 'normal' | 'fallback' | 'error';
 interface UseImageStatusParams {
   src: string;
   fallbackSrc?: string;
+  onLoad?: (event: SyntheticEvent<HTMLImageElement>) => void;
   onError?: (event: SyntheticEvent<HTMLImageElement>) => void;
 }
 
@@ -18,6 +19,7 @@ interface UseImageStatusResult {
 export function useImageStatus({
   src,
   fallbackSrc,
+  onLoad: onLoadFromProps,
   onError: onErrorFromProps,
 }: UseImageStatusParams): UseImageStatusResult {
   const [status, setStatus] = useState<ImageStatus>('loading');
@@ -28,9 +30,13 @@ export function useImageStatus({
     setStatus('loading');
   }, [src]);
 
-  const handleLoad = useCallback((_event: SyntheticEvent<HTMLImageElement>) => {
-    setStatus('normal');
-  }, []);
+  const handleLoad = useCallback(
+    (event: SyntheticEvent<HTMLImageElement>) => {
+      onLoadFromProps?.(event);
+      setStatus('normal');
+    },
+    [onLoadFromProps],
+  );
 
   const handleError = useCallback(
     (event: SyntheticEvent<HTMLImageElement>) => {

--- a/packages/image/src/hooks/useImageStatus.ts
+++ b/packages/image/src/hooks/useImageStatus.ts
@@ -1,0 +1,53 @@
+import { type SyntheticEvent, useCallback, useState } from 'react';
+
+export type ImageStatus = 'loading' | 'normal' | 'fallback' | 'error';
+
+interface UseImageStatusParams {
+  src: string;
+  fallbackSrc?: string;
+  onError?: (event: SyntheticEvent<HTMLImageElement>) => void;
+}
+
+interface UseImageStatusResult {
+  status: ImageStatus;
+  imgSrc: string;
+  handleLoad: (event: SyntheticEvent<HTMLImageElement>) => void;
+  handleError: (event: SyntheticEvent<HTMLImageElement>) => void;
+}
+
+export function useImageStatus({
+  src,
+  fallbackSrc,
+  onError: onErrorFromProps,
+}: UseImageStatusParams): UseImageStatusResult {
+  const [status, setStatus] = useState<ImageStatus>('loading');
+  const [imgSrc, setImgSrc] = useState(src);
+  const [hasTriedFallback, setHasTriedFallback] = useState(false);
+
+  const handleLoad = useCallback((_event: SyntheticEvent<HTMLImageElement>) => {
+    setStatus('normal');
+  }, []);
+
+  const handleError = useCallback(
+    (event: SyntheticEvent<HTMLImageElement>) => {
+      onErrorFromProps?.(event);
+
+      if (!hasTriedFallback && fallbackSrc) {
+        setImgSrc(fallbackSrc);
+        setHasTriedFallback(true);
+        setStatus('loading');
+        return;
+      }
+
+      setStatus('error');
+    },
+    [fallbackSrc, hasTriedFallback, onErrorFromProps],
+  );
+
+  return {
+    status,
+    imgSrc,
+    handleLoad,
+    handleError,
+  };
+}

--- a/packages/image/src/index.ts
+++ b/packages/image/src/index.ts
@@ -1,2 +1,1 @@
-export * from './hooks/useImageStatus';
 export * from './Image';

--- a/packages/image/src/index.ts
+++ b/packages/image/src/index.ts
@@ -1,0 +1,2 @@
+export * from './hooks/useImageStatus';
+export * from './Image';

--- a/packages/image/tsconfig.json
+++ b/packages/image/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/image/tsup.config.ts
+++ b/packages/image/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  clean: true,
+  dts: true,
+  format: ['esm', 'cjs'],
+});

--- a/packages/image/tsup.config.ts
+++ b/packages/image/tsup.config.ts
@@ -1,8 +1,3 @@
-import { defineConfig } from 'tsup';
+import defaultConfig from '../../tsup.config';
 
-export default defineConfig({
-  entry: ['src/index.ts'],
-  clean: true,
-  dts: true,
-  format: ['esm', 'cjs'],
-});
+export default defaultConfig;

--- a/packages/image/vitest.config.ts
+++ b/packages/image/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineProject, mergeConfig } from 'vitest/config';
+
+import defaultConfig from '../../vitest.config';
+
+export default mergeConfig(
+  defaultConfig,
+  defineProject({
+    test: {
+      setupFiles: './vitest.setup.ts',
+    },
+  }),
+);

--- a/packages/image/vitest.setup.ts
+++ b/packages/image/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/packages/side/package.json
+++ b/packages/side/package.json
@@ -25,6 +25,7 @@
     "@sipe-team/button": "workspace:*",
     "@sipe-team/card": "workspace:*",
     "@sipe-team/divider": "workspace:*",
+    "@sipe-team/image": "workspace:*",
     "@sipe-team/input": "workspace:*",
     "@sipe-team/radio": "workspace:*",
     "@sipe-team/skeleton": "workspace:*",

--- a/packages/side/src/index.ts
+++ b/packages/side/src/index.ts
@@ -3,6 +3,7 @@ export * from '@sipe-team/button';
 export * from '@sipe-team/card';
 export * from '@sipe-team/divider';
 export * from '@sipe-team/flex';
+export * from '@sipe-team/image';
 export * from '@sipe-team/input';
 export * from '@sipe-team/radio';
 export * from '@sipe-team/skeleton';

--- a/packages/side/styles.css
+++ b/packages/side/styles.css
@@ -3,6 +3,7 @@
 @import "~@sipe-team/card/styles.css";
 @import "~@sipe-team/divider/styles.css";
 @import "~@sipe-team/flex/styles.css";
+@import "~@sipe-team/image/styles.css";
 @import "~@sipe-team/input/styles.css";
 @import "~@sipe-team/radio/styles.css";
 @import "~@sipe-team/skeleton/styles.css";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -714,6 +714,10 @@ importers:
         version: 2.1.8(@types/node@22.10.1)(happy-dom@15.11.7)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.37.0)
 
   packages/image:
+    dependencies:
+      clsx:
+        specifier: 'catalog:'
+        version: 2.1.1
     devDependencies:
       '@testing-library/jest-dom':
         specifier: 'catalog:'
@@ -724,6 +728,12 @@ importers:
       '@types/react':
         specifier: catalog:react
         version: 18.3.13
+      '@vanilla-extract/css':
+        specifier: 'catalog:'
+        version: 1.20.1
+      '@vanilla-extract/dynamic':
+        specifier: 'catalog:'
+        version: 2.1.5
       happy-dom:
         specifier: 'catalog:'
         version: 15.11.7
@@ -944,6 +954,9 @@ importers:
       '@sipe-team/flex':
         specifier: workspace:*
         version: link:../flex
+      '@sipe-team/image':
+        specifier: workspace:*
+        version: link:../image
       '@sipe-team/input':
         specifier: workspace:*
         version: link:../input

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -715,6 +715,9 @@ importers:
 
   packages/image:
     dependencies:
+      '@sipe-team/tokens':
+        specifier: workspace:*
+        version: link:../tokens
       clsx:
         specifier: 'catalog:'
         version: 2.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -713,6 +713,36 @@ importers:
         specifier: 'catalog:'
         version: 2.1.8(@types/node@22.10.1)(happy-dom@15.11.7)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.37.0)
 
+  packages/image:
+    devDependencies:
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.6.3
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/react':
+        specifier: catalog:react
+        version: 18.3.13
+      happy-dom:
+        specifier: 'catalog:'
+        version: 15.11.7
+      react:
+        specifier: catalog:react
+        version: 18.3.1
+      react-dom:
+        specifier: catalog:react
+        version: 18.3.1(react@18.3.1)
+      tsup:
+        specifier: 'catalog:'
+        version: 8.5.1(jiti@2.4.1)(postcss@8.5.9)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.1)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.6.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.8(@types/node@22.10.1)(happy-dom@15.11.7)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.37.0)
+
   packages/input:
     dependencies:
       '@radix-ui/react-slot':


### PR DESCRIPTION
## Changes
@sipe-team/image 패키지의 Image 컴포넌트 초기 구현입니다.

### Image 컴포넌트 기본 동작 구현
- src, alt 필수
- width, height (number | string) 지원
- fit 지원 (contain | cover | fill, 기본값 cover)
- fill 지원
- loading 기본값 lazy
- placeholder 지원

### useImageStatus 훅 분리
에러/대체 이미지 상태 관리를 위해 useImageStatus 훅을 추가했습니다.
- 상태: loading | normal | fallback | error
- fallback 1회 전환 + 무한루프 방지 (hasTriedFallback 플래그)
- onError 콜백 호출 보장

### Storybook Components/Image 추가
- Basic, Fallbacks, WithPlaceholder, WithFill, Fits, ResponsiveWidth
- 각 스토리 설명(docs.description.story) 추가

### Image 테스트 코드 추가
총 8개 케이스를 작성했습니다 (`packages/image/src/Image.test.tsx`)
- src, alt 필수 전달 시 이미지 정상 렌더링 여부 확인
- width={320}, height="50%" 같이 number/string 혼합 입력이 스타일로 반영되는지 확인
- 첫 에러 발생 시 fallbackSrc로 1회 전환되는지 확인
- fallbackSrc가 없을 때 에러 상태로 전환되고 이미지가 visibility: hidden 처리되는지 확인
- 로딩 중 placeholder 노출, load 이벤트 후 placeholder 제거되는지 확인
- fill 사용 시 position: absolute, width/height: 100% 스타일 적용 확인
- loading prop 미지정 시 기본값 lazy 확인
- 에러 발생 시 사용자 onError 콜백이 항상 호출되는지 확인

## Visuals

- Basic — 기본 렌더링
<img width="907" height="896" alt="스크린샷 2026-04-28 오후 5 29 25" src="https://github.com/user-attachments/assets/af7b8978-cb51-4c68-87ac-39cb54d3cfa1" />

- Fallbacks : (fallbackSrc 있음 = fallback 전환 / 없음 = 영역 유지, 이미지 숨김)
<img width="891" height="438" alt="스크린샷 2026-04-28 오후 5 30 04" src="https://github.com/user-attachments/assets/27b7f3d8-0727-4011-9870-d986a3f0763d" />

- WithPlaceholder — 로딩 중 placeholder
https://github.com/user-attachments/assets/10505675-28da-4180-9137-07aa02207c49

- WithFill — fill 동작
<img width="843" height="410" alt="스크린샷 2026-04-28 오후 5 37 33" src="https://github.com/user-attachments/assets/80aa2362-851a-4a1e-818c-7a66ce8fcb58" />

- Filts : object-fit 동작
<img width="830" height="446" alt="스크린샷 2026-04-28 오후 5 36 42" src="https://github.com/user-attachments/assets/271f6224-ed64-484e-8a1b-9acd480e355d" />

- ResponsiveWidth : 반응형 너비
<img width="830" height="446" alt="스크린샷 2026-04-28 오후 5 36 42" src="https://github.com/user-attachments/assets/271f6224-ed64-484e-8a1b-9acd480e355d" />

## Checklist
- [X] Have you written the functional specifications?
- [X] Have you written the test code?

## Additional Discussion Points

### 디자인시스템 레퍼런스 분석 기준
구현 방향을 잡기 위해 Ant Design, Chakra UI v3, Mantine, Next.js 총 4개 디자인시스템의 Image 컴포넌트를 분석했습니다.
노션 링크 내부에 각 레퍼런스별 공식문서와 github 링크, 파악한 내용 정리한 부분을 첨부합니다.

- [Ant Design 노션 링크](https://minjeeki.notion.site/Ant-Design-350196bee1fc80b3bccedf735ebd2e20?source=copy_link)
- [NextJS 노션 링크](https://minjeeki.notion.site/Next-js-star-139k-350196bee1fc808a90dfed73fa1fd3f7?source=copy_link)
- [Mantine 노션 링크](https://minjeeki.notion.site/Mantine-star-31-3k-350196bee1fc80ffbe10f385924d5051?source=copy_link)
- [Chakra 노션 링크](https://minjeeki.notion.site/Chakra-UI-star-40-4k-350196bee1fc80fa8359c3950dd39162?source=copy_link)

### 채택한 방향
- 상태 loading / normal / fallback / error 4단계로 분리하는 구조 : Ant Design 참고
- 에러 시 visibility: hidden으로 공간을 유지하는 방식 : Ant Design 참고
- fallbackSrc prop 제공 + onError 콜백은 항상 호출하는 방식 : Ant Design + Next.js 참고
- fallback 1회 전환 후 무한루프 방지(hasTriedFallback)는 레퍼런스에 없는 방식으로 직접 추가

### 팀원들과 논의를 하고 싶은 부분
- 에러 표시 정책
  현재는 visibility: hidden으로 공간을 유지하면서 내용을 숨기는 방식으로 구현했습니다. Ant Design과 동일한 방식입니다. 기본 fallback UI를 내장하는 방향으로 가면 에러 상태가 더 명확해지고 일관성도 높아질 것 같아서, 디자인팀과 UI 형태를 논의한 후 추가하는 방향을 제안합니다.
- radius, size 등에 대한 토큰 처리 관련
  현재는 사용자가 직접 값을 입력하는 방식으로 열어뒀습니다. 토큰 관련해서 논의 후에 진행하는 것이 좋을 것 같습니다.
- aspectRatio prop 처리 여부 관련
  현재 서비스에서 비율로 처리하는 케이스가 한 곳으로 CSS로도 대응 가능한 수준이라 제외했습니다. 실제로 쓰다가 불편하다는 피드백이 오면 그때 추가하는 방향을 고민해봤습니다.
- next/image 관련
  현재는 <img> 기반 코어로만 구현했습니다. next/image는 자체적으로 최적화와 로딩 처리를 하기 때문에 우리 상태 관리와 충돌이 생길 수 있어서, 별도 패키지(@sipe-team/image-next)로 분리해서 작업하는 방향을 고민해봤습니다.
  
늦게 올려서 죄송합니다. 작업이 처음이라 부족한 부분이 많을 것 같습니다.. 피드백 주시면 최대한 열심히 찾아보겠습니다.