### PR TITLE
feat(Card): add ghost variant with transparent background and no border

### DIFF
--- a/.changeset/add-card-ghost-variant.md
+++ b/.changeset/add-card-ghost-variant.md
@@ -1,0 +1,5 @@
+---
+"@sipe-team/card": minor
+---
+
+Add ghost variant to Card component with transparent background, no border, and no padding

--- a/packages/card/src/Card.css.ts
+++ b/packages/card/src/Card.css.ts
@@ -5,6 +5,7 @@ import { recipe } from '@vanilla-extract/recipes';
 export const CardVariant = {
   filled: 'filled',
   outline: 'outline',
+  ghost: 'ghost',
 } as const;
 
 export const CardRatio = {
@@ -35,6 +36,11 @@ export const card = recipe({
       [CardVariant.outline]: {
         backgroundColor: color.gray50,
         border: `1px solid ${color.cyan300}`,
+      },
+      [CardVariant.ghost]: {
+        backgroundColor: 'transparent',
+        border: 'none',
+        padding: 0,
       },
     },
     ratio: {

--- a/packages/card/src/Card.stories.tsx
+++ b/packages/card/src/Card.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
     },
     variant: {
       control: 'select',
-      options: ['filled', 'outline'],
+      options: ['filled', 'outline', 'ghost'],
     },
   },
 } satisfies Meta<typeof Card>;
@@ -133,6 +133,51 @@ export const OutlineVariant: Story = {
 
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '10px' }}>
           <Card variant="outline" ratio="auto" style={{ width: '250px', height: '150px' }}>
+            <RatioVisualizer label="Auto" ratio="Custom" />
+          </Card>
+          <div>Auto (Custom Size)</div>
+        </div>
+      </div>
+    </div>
+  ),
+};
+
+// Ghost variant with all ratios in a row
+export const GhostVariant: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '40px', maxWidth: '1000px' }}>
+      <h3>Ghost Variant - All Ratios</h3>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))', gap: '30px' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '10px' }}>
+          <Card variant="ghost" ratio="rectangle" style={{ width: '250px' }}>
+            <RatioVisualizer label="Rectangle" ratio="16:9" />
+          </Card>
+          <div>Rectangle (16:9)</div>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '10px' }}>
+          <Card variant="ghost" ratio="square" style={{ width: '250px' }}>
+            <RatioVisualizer label="Square" ratio="1:1" />
+          </Card>
+          <div>Square (1:1)</div>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '10px' }}>
+          <Card variant="ghost" ratio="wide" style={{ width: '250px' }}>
+            <RatioVisualizer label="Wide" ratio="21:9" />
+          </Card>
+          <div>Wide (21:9)</div>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '10px' }}>
+          <Card variant="ghost" ratio="portrait" style={{ width: '200px' }}>
+            <RatioVisualizer label="Portrait" ratio="3:4" />
+          </Card>
+          <div>Portrait (3:4)</div>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '10px' }}>
+          <Card variant="ghost" ratio="auto" style={{ width: '250px', height: '150px' }}>
             <RatioVisualizer label="Auto" ratio="Custom" />
           </Card>
           <div>Auto (Custom Size)</div>

--- a/packages/card/src/Card.test.tsx
+++ b/packages/card/src/Card.test.tsx
@@ -81,3 +81,24 @@ test(`variant가 outline일 때 배경색이 ${color.gray50}이다.`, () => {
     backgroundColor: color.gray50,
   });
 });
+
+test('ghost variant has transparent background', () => {
+  render(<Card variant="ghost">Card</Card>);
+  expect(screen.getByText('Card')).toHaveStyle({
+    backgroundColor: 'transparent',
+  });
+});
+
+test('ghost variant has no border', () => {
+  render(<Card variant="ghost">Card</Card>);
+  expect(screen.getByText('Card')).toHaveStyle({
+    border: 'none',
+  });
+});
+
+test('ghost variant has no padding', () => {
+  render(<Card variant="ghost">Card</Card>);
+  expect(screen.getByText('Card')).toHaveStyle({
+    padding: '0',
+  });
+});


### PR DESCRIPTION
Fixed #264 

## Changes
Card 컴포넌트에 `ghost` variant를 추가했습니다. 실제 SIPE 공식 홈페이지 코드로도 테스트 완료했습니다!

- `Card.css.ts`: `CardVariant`에 `ghost` 옵션 추가 (배경색: transparent, border: none, padding: 0)
- `Card.test.tsx`: ghost variant에 대한 테스트 3개 추가 (배경색, border, padding 검증)
- `Card.stories.tsx`: argTypes에 `ghost` 옵션 추가 및 `GhostVariant` 스토리 추가 (모든 ratio 조합 포함)
- `.changeset/add-card-ghost-variant.md`: `@sipe-team/card` minor 버전 changeset 추가

## Visuals
<!-- Storybook에서 GhostVariant 스토리를 확인해주세요. (`pnpm dev:storybook`) -->

## Checklist
- [x] Have you written the functional specifications?
- [x] Have you written the test code?

## Additional Discussion Points
- `ghost` variant는 배경과 테두리가 없는 투명한 카드로, 레이아웃 용도나 콘텐츠만 감싸는 경우에 활용할 수 있습니다.
