### PR TITLE
chore: add title option to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,7 @@ jobs:
           version: pnpm changeset version
           publish: pnpm changeset publish
           commit: "chore(release): version packages"
+          title: "chore(release): version packages"
         env:
           HUSKY: 0
           GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}


### PR DESCRIPTION
## Summart

`changesets/action`이 자동 생성하는 Release PR의 제목을 `title` 옵션으로 명시적으로 지정합니다.


기존에는 `title`이 없어 기본값인 `"Version Packages"`로 생성되었는데, `commit` 메시지와 동일하게 컨벤셔널 커밋 형식으로 통일했습니다.

- https://github.com/sipe-team/side/pull/260

```yaml
title: "chore(release): version packages"
```

main에 먼저 넣어야 다음 release에 적용될거같아서 main으로 바로 넣고 cherry-pick 할게요. 

## 레퍼런스

shadcn/ui도 동일한 방식으로 `title`과 `commit`을 함께 명시하고 있습니다.
- https://github.com/shadcn-ui/ui/blob/main/.github/workflows/release.yml