### PR TITLE
chore(biome): remove unsafe flag from claude hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,7 +34,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pnpm biome check --write --unsafe $CLAUDE_FILE_PATHS",
+            "command": "pnpm biome check --write $CLAUDE_FILE_PATHS",
             "timeout": 10,
             "statusMessage": "Biome 포맷팅 중..."
           }


### PR DESCRIPTION
## Changes

Claude Code hooks에서 `biome check --write`에 붙어 있던 `--unsafe` 플래그를 제거합니다.

`--unsafe` 옵션은 코드 동작을 변경할 수 있는 수정까지 자동으로 적용합니다.  
예를 들어 `var → const/let` 변환(스코프 변경), 미사용 변수 자동 삭제 등이 해당됩니다.  
Claude가 파일을 저장할 때마다 이런 수정이 자동으로 일어나면 의도치 않은 로직 변경으로 이어질 수 있어 제거합니다.

> 참고: [Biome — Safe and Unsafe Fixes](https://biomejs.dev/linter/#safe-fixes)

## Visuals
<!-- If there are any screenshots or visual materials, please attach them. -->

## Checklist
- [ ] Have you written the functional specifications?
- [ ] Have you written the test code?

## Additional Discussion Points
<!-- If there are any additional points to be aware of, please specify them. -->