### PR TITLE
feat(tokens): Connect VE theme values to the SD CSS variable pipeline

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,6 +1,8 @@
 import 'sanitize.css';
 import 'sanitize.css/typography.css';
 
+import '@sipe-team/tokens/styles.css';
+
 import type { Preview } from '@storybook/react';
 
 export default {

--- a/packages/tokens/config.js
+++ b/packages/tokens/config.js
@@ -24,6 +24,76 @@ function toPascalCase(str) {
     .join('');
 }
 
+/**
+ * Primitive + Semantic 토큰을 합칠 때 같은 최상위 키(color, radius 등)가
+ * shallow merge로 덮어씌워지지 않도록 재귀 병합.
+ * @param {Record<string, unknown>} target
+ * @param {Record<string, unknown>} source
+ */
+function deepMerge(target, source) {
+  const result = { ...target };
+  for (const key of Object.keys(source)) {
+    if (
+      source[key] !== null &&
+      typeof source[key] === 'object' &&
+      !Array.isArray(source[key]) &&
+      target[key] !== null &&
+      typeof target[key] === 'object' &&
+      !Array.isArray(target[key])
+    ) {
+      result[key] = deepMerge(
+        /** @type {Record<string, unknown>} */ (target[key]),
+        /** @type {Record<string, unknown>} */ (source[key]),
+      );
+    } else {
+      result[key] = source[key];
+    }
+  }
+  return result;
+}
+
+/**
+ * Semantic 토큰 집합을 CSS 변수 파일로 빌드.
+ * Primitive 토큰을 함께 로드해 cross-set 참조({color.gray.950} 등)를 해소하되,
+ * filter로 참조값을 가진 semantic 토큰만 출력.
+ * @param {string} setPrefix
+ * @param {string} outputFile
+ */
+async function _buildSemanticPlatform(setPrefix, outputFile) {
+  if (!hasSetsByPrefix(setPrefix)) {
+    mkdirSync(DIST, { recursive: true });
+    writeFileSync(`${DIST}/${outputFile}`, `/* ${setPrefix} tokens not yet defined */\n`);
+    return;
+  }
+
+  const semanticSets = Object.keys(allTokens).filter((key) => key !== '$metadata' && key.startsWith(setPrefix));
+
+  const sd = new StyleDictionary({
+    tokens: deepMerge(mergeSets(PRIMITIVE_SETS), mergeSets(semanticSets)),
+    platforms: {
+      css: {
+        transformGroup: 'css',
+        buildPath: `${DIST}/`,
+        files: [
+          {
+            destination: outputFile,
+            format: 'css/variables',
+            // 참조값({...})을 가진 토큰만 출력 = semantic tokens only
+            filter: (token) => {
+              const origValue = token.original?.$value ?? token.original?.value ?? '';
+              return typeof origValue === 'string' && origValue.startsWith('{');
+            },
+            options: { selector: ':root', outputReferences: true },
+          },
+        ],
+      },
+    },
+  });
+  await sd.buildAllPlatforms();
+}
+
+const PRIMITIVE_SETS = ['primitive/color', 'primitive/radius', 'primitive/spacing', 'primitive/typography'];
+
 // Build primitive tokens (CSS + TypeScript types)
 const primitive = new StyleDictionary({
   source: ['../../tokens/primitive/**/*.json'],
@@ -138,8 +208,19 @@ if (hasJsonFiles(SEMANTIC_LIGHT_DIR)) {
   writeFileSync(`${DIST}/semantic-light.css`, '/* semantic/light tokens not yet defined */\n');
 }
 
+// Build semantic tokens — dark color / radius / spacing
+await _buildSemanticPlatform('semantic/dark', 'semantic-dark.css');
+await _buildSemanticPlatform('semantic/radius', 'semantic-radius.css');
+await _buildSemanticPlatform('semantic/spacing', 'semantic-spacing.css');
+
 // Concatenate all CSS into index.css
-const parts = [readFileSync(`${DIST}/primitive.css`, 'utf-8'), readFileSync(`${DIST}/semantic-light.css`, 'utf-8')];
+const parts = [
+  readFileSync(`${DIST}/primitive.css`, 'utf-8'),
+  readFileSync(`${DIST}/semantic-dark.css`, 'utf-8'),
+  readFileSync(`${DIST}/semantic-radius.css`, 'utf-8'),
+  readFileSync(`${DIST}/semantic-spacing.css`, 'utf-8'),
+  readFileSync(`${DIST}/semantic-light.css`, 'utf-8'),
+];
 writeFileSync(`${DIST}/index.css`, parts.join('\n'));
 console.log(`✓ ${DIST}/index.css generated`);
 

--- a/packages/tokens/config.js
+++ b/packages/tokens/config.js
@@ -5,16 +5,22 @@ import StyleDictionary from 'style-dictionary';
 
 chdir(import.meta.dirname);
 
+// ─── Types ───────────────────────────────────────────────────────────────────
+/**
+ * @typedef {{ $value: unknown, $type?: string, $description?: string }} DtcgToken
+ * @typedef {{ [key: string]: DtcgToken | DtcgTokenGroup }} DtcgTokenGroup
+ * @typedef {{ glob: string }} PrimitiveConfig
+ * @typedef {{ glob: string, output: string, required: boolean }} SemanticEntry
+ * @typedef {{ primitive: PrimitiveConfig, semantic: SemanticEntry[] }} BuildManifest
+ */
+
+/** @type {BuildManifest} */
+const manifest = JSON.parse(readFileSync('./tokens.build.json', 'utf-8'));
+
 const DIST = 'dist/css';
 const DIST_TS = 'dist/ts';
-const SEMANTIC_LIGHT_DIR = '../../tokens/semantic/light';
 
-/** @param {string} dir */
-function hasJsonFiles(dir) {
-  if (!existsSync(dir)) return false;
-  const entries = readdirSync(dir, { recursive: true });
-  return entries.some((f) => f.toString().endsWith('.json'));
-}
+// ─── Helpers ─────────────────────────────────────────────────────────────────
 
 /** @param {string} str */
 function toPascalCase(str) {
@@ -25,64 +31,53 @@ function toPascalCase(str) {
 }
 
 /**
- * Primitive + Semantic 토큰을 합칠 때 같은 최상위 키(color, radius 등)가
- * shallow merge로 덮어씌워지지 않도록 재귀 병합.
- * @param {Record<string, unknown>} target
- * @param {Record<string, unknown>} source
+ * 파일 경로 또는 glob 패턴에 해당하는 JSON 파일 존재 여부 확인.
+ * @param {string} globOrPath
+ * @returns {boolean}
  */
-function deepMerge(target, source) {
-  const result = { ...target };
-  for (const key of Object.keys(source)) {
-    if (
-      source[key] !== null &&
-      typeof source[key] === 'object' &&
-      !Array.isArray(source[key]) &&
-      target[key] !== null &&
-      typeof target[key] === 'object' &&
-      !Array.isArray(target[key])
-    ) {
-      result[key] = deepMerge(
-        /** @type {Record<string, unknown>} */ (target[key]),
-        /** @type {Record<string, unknown>} */ (source[key]),
-      );
-    } else {
-      result[key] = source[key];
-    }
+function hasMatchingFiles(globOrPath) {
+  if (!globOrPath.includes('*')) {
+    return existsSync(globOrPath);
   }
-  return result;
+  const baseDir = globOrPath.replace(/\/\*\*\/\*\.json$/, '').replace(/\/\*\.json$/, '');
+  if (!existsSync(baseDir)) return false;
+  return /** @type {string[]} */ (readdirSync(baseDir, { recursive: true })).some((f) =>
+    f.toString().endsWith('.json'),
+  );
 }
 
+// ─── Semantic build ───────────────────────────────────────────────────────────
+
 /**
- * Semantic 토큰 집합을 CSS 변수 파일로 빌드.
- * Primitive 토큰을 함께 로드해 cross-set 참조({color.gray.950} 등)를 해소하되,
- * filter로 참조값을 가진 semantic 토큰만 출력.
- * @param {string} setPrefix
- * @param {string} outputFile
+ * Semantic 토큰을 CSS 변수 파일로 빌드.
+ * Primitive 토큰을 `include`로 로드해 cross-set 참조({color.gray.950} 등)를 해소하되,
+ * `source`에 지정된 semantic 토큰만 출력.
+ * @param {SemanticEntry} entry
  */
-async function _buildSemanticPlatform(setPrefix, outputFile) {
-  if (!hasSetsByPrefix(setPrefix)) {
+async function buildSemanticPlatform({ glob, output, required }) {
+  if (!hasMatchingFiles(glob)) {
+    if (required) {
+      throw new Error(
+        `[tokens] Required semantic token set not found: "${glob}"\n` +
+          `→ Add the token file/directory or remove the entry from tokens.build.json.`,
+      );
+    }
     mkdirSync(DIST, { recursive: true });
-    writeFileSync(`${DIST}/${outputFile}`, `/* ${setPrefix} tokens not yet defined */\n`);
+    writeFileSync(`${DIST}/${output}`, `/* ${glob} not yet defined */\n`);
     return;
   }
 
-  const semanticSets = Object.keys(allTokens).filter((key) => key !== '$metadata' && key.startsWith(setPrefix));
-
   const sd = new StyleDictionary({
-    tokens: deepMerge(mergeSets(PRIMITIVE_SETS), mergeSets(semanticSets)),
+    include: [manifest.primitive.glob],
+    source: [glob],
     platforms: {
       css: {
         transformGroup: 'css',
         buildPath: `${DIST}/`,
         files: [
           {
-            destination: outputFile,
+            destination: output,
             format: 'css/variables',
-            // 참조값({...})을 가진 토큰만 출력 = semantic tokens only
-            filter: (token) => {
-              const origValue = token.original?.$value ?? token.original?.value ?? '';
-              return typeof origValue === 'string' && origValue.startsWith('{');
-            },
             options: { selector: ':root', outputReferences: true },
           },
         ],
@@ -92,11 +87,10 @@ async function _buildSemanticPlatform(setPrefix, outputFile) {
   await sd.buildAllPlatforms();
 }
 
-const PRIMITIVE_SETS = ['primitive/color', 'primitive/radius', 'primitive/spacing', 'primitive/typography'];
+// ─── Primitive build ──────────────────────────────────────────────────────────
 
-// Build primitive tokens (CSS + TypeScript types)
 const primitive = new StyleDictionary({
-  source: ['../../tokens/primitive/**/*.json'],
+  source: [manifest.primitive.glob],
   hooks: {
     formats: {
       'typescript/token-names-dts': ({ dictionary }) => {
@@ -162,69 +156,33 @@ const primitive = new StyleDictionary({
       transforms: ['name/kebab'],
       buildPath: `${DIST_TS}/`,
       files: [
-        {
-          destination: 'primitive.d.ts',
-          format: 'typescript/token-names-dts',
-        },
-        {
-          destination: 'primitive.d.cts',
-          format: 'typescript/token-names-dts',
-        },
-        {
-          destination: 'primitive.js',
-          format: 'typescript/token-names-js',
-        },
-        {
-          destination: 'primitive.cjs',
-          format: 'typescript/token-names-cjs',
-        },
+        { destination: 'primitive.d.ts', format: 'typescript/token-names-dts' },
+        { destination: 'primitive.d.cts', format: 'typescript/token-names-dts' },
+        { destination: 'primitive.js', format: 'typescript/token-names-js' },
+        { destination: 'primitive.cjs', format: 'typescript/token-names-cjs' },
       ],
     },
   },
 });
 await primitive.buildAllPlatforms();
 
-// Build semantic/light tokens — graceful no-op if directory is empty
-if (hasJsonFiles(SEMANTIC_LIGHT_DIR)) {
-  const semanticLight = new StyleDictionary({
-    source: [`${SEMANTIC_LIGHT_DIR}/**/*.json`],
-    platforms: {
-      css: {
-        transformGroup: 'css',
-        buildPath: `${DIST}/`,
-        files: [
-          {
-            destination: 'semantic-light.css',
-            format: 'css/variables',
-            options: { selector: ':root', outputReferences: true },
-          },
-        ],
-      },
-    },
-  });
-  await semanticLight.buildAllPlatforms();
-} else {
-  mkdirSync(DIST, { recursive: true });
-  writeFileSync(`${DIST}/semantic-light.css`, '/* semantic/light tokens not yet defined */\n');
+// ─── Semantic builds (manifest-driven) ───────────────────────────────────────
+
+for (const entry of manifest.semantic) {
+  await buildSemanticPlatform(entry);
 }
 
-// Build semantic tokens — dark color / radius / spacing
-await _buildSemanticPlatform('semantic/dark', 'semantic-dark.css');
-await _buildSemanticPlatform('semantic/radius', 'semantic-radius.css');
-await _buildSemanticPlatform('semantic/spacing', 'semantic-spacing.css');
+// ─── index.css (concat) ───────────────────────────────────────────────────────
 
-// Concatenate all CSS into index.css
 const parts = [
   readFileSync(`${DIST}/primitive.css`, 'utf-8'),
-  readFileSync(`${DIST}/semantic-dark.css`, 'utf-8'),
-  readFileSync(`${DIST}/semantic-radius.css`, 'utf-8'),
-  readFileSync(`${DIST}/semantic-spacing.css`, 'utf-8'),
-  readFileSync(`${DIST}/semantic-light.css`, 'utf-8'),
+  ...manifest.semantic.map(({ output }) => readFileSync(`${DIST}/${output}`, 'utf-8')),
 ];
 writeFileSync(`${DIST}/index.css`, parts.join('\n'));
 console.log(`✓ ${DIST}/index.css generated`);
 
-// token-names barrel (.js + .d.ts — consumed via publishConfig ./token-names export)
+// ─── token-names barrel ───────────────────────────────────────────────────────
+
 mkdirSync(DIST_TS, { recursive: true });
 writeFileSync(
   `${DIST_TS}/index.js`,

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -10,7 +10,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./token-names": "./dist/ts/index.js"
+    "./token-names": "./dist/ts/index.js",
+    "./styles.css": "./dist/css/index.css"
   },
   "files": [
     "dist"
@@ -60,7 +61,8 @@
           "types": "./dist/ts/index.d.cts",
           "default": "./dist/ts/index.cjs"
         }
-      }
+      },
+      "./styles.css": "./dist/css/index.css"
     }
   },
   "sideEffects": false

--- a/packages/tokens/src/theme/themes.css.ts
+++ b/packages/tokens/src/theme/themes.css.ts
@@ -1,52 +1,49 @@
 import { createGlobalTheme } from '@vanilla-extract/css';
 
-import { brandColor, color, themeColor } from '../colors/colors';
-import { radius } from '../effects/radius';
+import { themeColor } from '../colors/colors';
 import { shadows } from '../effects/shadows';
-import { spacing } from '../layout/spacing';
-import { fontSize, fontWeight, lineHeight } from '../typography/fonts';
 import { themeLayer, vars } from './contract.css';
 
 const baseTheme = {
   '@layer': themeLayer,
   spacing: {
     component: {
-      xs: `${spacing[1]}px`,
-      sm: `${spacing[2]}px`,
-      md: `${spacing[3]}px`,
-      lg: `${spacing[4]}px`,
-      xl: `${spacing[6]}px`,
+      xs: 'var(--spacing-component-xs)',
+      sm: 'var(--spacing-component-sm)',
+      md: 'var(--spacing-component-md)',
+      lg: 'var(--spacing-component-lg)',
+      xl: 'var(--spacing-component-xl)',
     },
     layout: {
-      sm: `${spacing[8]}px`,
-      md: `${spacing[10]}px`,
-      lg: `${spacing[12]}px`,
-      xl: `${spacing[16]}px`,
+      sm: 'var(--spacing-layout-sm)',
+      md: 'var(--spacing-layout-md)',
+      lg: 'var(--spacing-layout-lg)',
+      xl: 'var(--spacing-layout-xl)',
     },
   },
   typography: {
-    fontFamily: 'Pretendard, system-ui, sans-serif',
+    fontFamily: 'var(--typography-font-family-base)',
     fontSize: {
-      '050': `${fontSize[12]}px`,
-      '100': `${fontSize[14]}px`,
-      '200': `${fontSize[16]}px`,
-      '300': `${fontSize[18]}px`,
-      '400': `${fontSize[20]}px`,
-      '500': `${fontSize[24]}px`,
-      '600': `${fontSize[28]}px`,
-      '700': `${fontSize[32]}px`,
-      '800': `${fontSize[36]}px`,
-      '900': `${fontSize[48]}px`,
+      '050': 'var(--typography-font-size-12)',
+      '100': 'var(--typography-font-size-14)',
+      '200': 'var(--typography-font-size-16)',
+      '300': 'var(--typography-font-size-18)',
+      '400': 'var(--typography-font-size-20)',
+      '500': 'var(--typography-font-size-24)',
+      '600': 'var(--typography-font-size-28)',
+      '700': 'var(--typography-font-size-32)',
+      '800': 'var(--typography-font-size-36)',
+      '900': 'var(--typography-font-size-48)',
     },
     lineHeight: {
-      regular: `${lineHeight.regular}`,
-      compact: `${lineHeight.compact}`,
+      regular: 'var(--typography-line-height-regular)',
+      compact: 'var(--typography-line-height-compact)',
     },
     fontWeight: {
-      regular: `${fontWeight.regular}`,
-      medium: `${fontWeight.medium}`,
-      semiBold: `${fontWeight.semiBold}`,
-      bold: `${fontWeight.bold}`,
+      regular: 'var(--typography-font-weight-regular)',
+      medium: 'var(--typography-font-weight-medium)',
+      semiBold: 'var(--typography-font-weight-semi-bold)',
+      bold: 'var(--typography-font-weight-bold)',
     },
   },
   shadows: {
@@ -59,42 +56,58 @@ const baseTheme = {
   },
   radius: {
     component: {
-      sm: radius.sm,
-      md: radius.md,
-      lg: radius.lg,
-      xl: radius.xl,
-      full: radius.full,
+      sm: 'var(--radius-component-sm)',
+      md: 'var(--radius-component-md)',
+      lg: 'var(--radius-component-lg)',
+      xl: 'var(--radius-component-xl)',
+      full: 'var(--radius-component-full)',
     },
     layout: {
-      sm: radius.md,
-      md: radius.lg,
-      lg: radius.xl,
+      sm: 'var(--radius-layout-sm)',
+      md: 'var(--radius-layout-md)',
+      lg: 'var(--radius-layout-lg)',
     },
   },
 };
 
 const darkBaseColor = {
   background: {
-    base: color.gray950,
-    subtle: color.gray900,
-    muted: color.gray800,
+    base: 'var(--color-background-base)',
+    subtle: 'var(--color-background-subtle)',
+    muted: 'var(--color-background-muted)',
   },
   foreground: {
-    default: color.white,
-    subtle: color.gray400,
-    muted: color.gray500,
-    onAccent: color.white,
+    default: 'var(--color-foreground-default)',
+    subtle: 'var(--color-foreground-subtle)',
+    muted: 'var(--color-foreground-muted)',
+    onAccent: 'var(--color-foreground-on-accent)',
   },
   border: {
-    default: color.gray700,
-    strong: color.gray500,
-    focus: color.blue400,
+    default: 'var(--color-border-default)',
+    strong: 'var(--color-border-strong)',
+    focus: 'var(--color-border-focus)',
   },
   status: {
-    success: { foreground: color.green400, background: color.green900, border: color.green700 },
-    warning: { foreground: color.orange400, background: color.orange900, border: color.orange700 },
-    danger: { foreground: color.red400, background: color.red900, border: color.red700 },
-    info: { foreground: color.blue400, background: color.blue900, border: color.blue700 },
+    success: {
+      foreground: 'var(--color-status-success-foreground)',
+      background: 'var(--color-status-success-background)',
+      border: 'var(--color-status-success-border)',
+    },
+    warning: {
+      foreground: 'var(--color-status-warning-foreground)',
+      background: 'var(--color-status-warning-background)',
+      border: 'var(--color-status-warning-border)',
+    },
+    danger: {
+      foreground: 'var(--color-status-danger-foreground)',
+      background: 'var(--color-status-danger-background)',
+      border: 'var(--color-status-danger-border)',
+    },
+    info: {
+      foreground: 'var(--color-status-info-foreground)',
+      background: 'var(--color-status-info-background)',
+      border: 'var(--color-status-info-border)',
+    },
   },
 };
 
@@ -103,9 +116,9 @@ createGlobalTheme(':root', vars, {
   color: {
     ...darkBaseColor,
     accent: {
-      default: brandColor.default,
-      hover: brandColor.hover,
-      subtle: brandColor.subtle,
+      default: 'var(--color-accent-default)',
+      hover: 'var(--color-accent-hover)',
+      subtle: 'var(--color-accent-subtle)',
     },
   },
   mode: 'dark',
@@ -119,7 +132,7 @@ createGlobalTheme('[data-theme="1st"]', vars, {
     accent: {
       default: themeColor['1st'].primary,
       hover: themeColor['1st'].secondary,
-      subtle: color.green900,
+      subtle: 'var(--color-green-900)',
     },
   },
   mode: 'dark',
@@ -133,7 +146,7 @@ createGlobalTheme('[data-theme="2nd"]', vars, {
     accent: {
       default: themeColor['2nd'].primary,
       hover: themeColor['2nd'].secondary,
-      subtle: color.teal900,
+      subtle: 'var(--color-teal-900)',
     },
   },
   mode: 'dark',
@@ -147,7 +160,7 @@ createGlobalTheme('[data-theme="3rd"]', vars, {
     accent: {
       default: themeColor['3rd'].primary,
       hover: themeColor['3rd'].secondary,
-      subtle: color.cyan900,
+      subtle: 'var(--color-cyan-900)',
     },
   },
   mode: 'dark',
@@ -161,7 +174,7 @@ createGlobalTheme('[data-theme="4th"]', vars, {
     accent: {
       default: themeColor['4th'].primary,
       hover: themeColor['4th'].secondary,
-      subtle: color.pink900,
+      subtle: 'var(--color-pink-900)',
     },
   },
   mode: 'dark',

--- a/packages/tokens/tokens.build.json
+++ b/packages/tokens/tokens.build.json
@@ -1,0 +1,11 @@
+{
+  "primitive": {
+    "glob": "../../tokens/primitive/**/*.json"
+  },
+  "semantic": [
+    { "glob": "../../tokens/semantic/dark/**/*.json", "output": "semantic-dark.css", "required": true },
+    { "glob": "../../tokens/semantic/radius.json", "output": "semantic-radius.css", "required": true },
+    { "glob": "../../tokens/semantic/spacing.json", "output": "semantic-spacing.css", "required": true },
+    { "glob": "../../tokens/semantic/light/**/*.json", "output": "semantic-light.css", "required": false }
+  ]
+}


### PR DESCRIPTION
## Summary

Style Dictionary v5 ESM 빌드 파이프라인 구축

## Changes

- **packages/tokens/config.js**: 계층형 토큰 병합 및 의미 토큰 전용 빌드 로직 추가
- **packages/tokens/src/theme/themes.css.ts**: 하드코딩된 값을 Style Dictionary 생성 CSS 변수 참조로 전환
- **packages/tokens/package.json**: 생성된 스타일을 외부에서 사용할 수 있도록 `./styles.css` export 추가
- **.storybook/preview.ts**: 스타일 적용 순서 보장을 위해 토큰 CSS 임포트 추가