### PR TITLE
fix(husky): update pre-push branch regex for dev

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,7 +2,7 @@
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 
 # Special branches that skip naming rules
-SPECIAL_REGEX='^(main|dev\/.+)$'
+SPECIAL_REGEX='^(main|dev)$'
 
 # Standard branch naming: <TYPE>/<SUBJECT>-<USERNAME>
 # At least one hyphen required (to enforce username suffix)


### PR DESCRIPTION
## Changes

`dev/*` 패턴을 `dev`로 변경합니다.

기존 `dev/.+` 패턴은 `dev/feature` 같은 브랜치를 위한 것이었으나 현재 해당 패턴의 브랜치가 없고 `dev` 브랜치 자체로 직접 push할 일이 생겨 수정합니다.

```diff
- SPECIAL_REGEX='^(main|dev\/.+)$'
+ SPECIAL_REGEX='^(main|dev)$'
```

## Checklist
- [ ] Have you written the functional specifications?
- [ ] Have you written the test code?