### PR TITLE
build(release): gate publish behind export map validation

### DIFF
--- a/.changeset/accordion-grid-compile-styles.md
+++ b/.changeset/accordion-grid-compile-styles.md
@@ -1,0 +1,6 @@
+---
+"@sipe-team/accordion": patch
+"@sipe-team/grid": patch
+---
+
+Compile vanilla-extract styles so `./styles.css` resolves. Both packages declared a local `tsup` config without the vanilla-extract plugin, so their `.css.ts` styles were never compiled and the `dist/index.css` referenced by `publishConfig.exports["./styles.css"]` was absent from the published tarball. They now reuse the shared root config like every other component package, and shipped without styles until now.

--- a/.changeset/reset-css-export-path.md
+++ b/.changeset/reset-css-export-path.md
@@ -1,0 +1,5 @@
+---
+"@sipe-team/reset": patch
+---
+
+Point the `./reset.css` export at the emitted stylesheet. It referenced `./dist/reset.css`, but the build emits `./dist/index.css`, so importing `@sipe-team/reset/reset.css` failed to resolve.

--- a/.changeset/tokens-token-names-resolution.md
+++ b/.changeset/tokens-token-names-resolution.md
@@ -1,0 +1,5 @@
+---
+"@sipe-team/tokens": patch
+---
+
+Fix `@sipe-team/tokens/token-names` failing to resolve under node16 ESM. The generated barrel declaration re-exported `./primitive` and `./semantic` without runtime extensions, and the types-only semantic layer had no runtime module behind it, so TypeScript could not resolve the sibling declarations. The barrel now emits extension-qualified specifiers and a runtime stub for the semantic layer.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,32 +26,17 @@ jobs:
 
   # Runs in parallel with CI. Validates the packed tarballs, which are the only place the
   # publishConfig.exports swap is ever exercised — no other job can catch a broken export map.
-  # The job always runs (so it stays usable as a required check) but does the work only when the
-  # published output could have changed. Within a package it is deliberately unscoped: packing one
-  # package builds its workspace dependencies too, so a change anywhere can break another tarball.
+  # Deliberately unscoped: packing one package builds its workspace dependencies too, so a change
+  # anywhere can break another package's tarball.
   publishability:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
     - uses: jdx/mise-action@v2
-    - name: Detect changes to published output
-      id: changes
-      run: |
-        git fetch --quiet origin "${{ github.base_ref }}"
-        if git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
-          | grep -qE '^(packages/|pnpm-lock\.yaml|pnpm-workspace\.yaml|tsup\.config\.ts|package\.json|scripts/checkPublishability\.sh)'; then
-          echo "affected=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "affected=false" >> "$GITHUB_OUTPUT"
-          echo "No changes to published output; skipping." >> "$GITHUB_STEP_SUMMARY"
-        fi
     - name: Install dependencies
-      if: steps.changes.outputs.affected == 'true'
       run: pnpm install
     - name: Check publishability
-      if: steps.changes.outputs.affected == 'true'
       run: pnpm lint:publish

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,3 +23,35 @@ jobs:
       run: pnpm --filter="...[origin/${{ github.base_ref }}]" --if-present typecheck
     - name: Build
       run: pnpm --filter="...[origin/${{ github.base_ref }}]" --if-present build
+
+  # Runs in parallel with CI. Validates the packed tarballs, which are the only place the
+  # publishConfig.exports swap is ever exercised — no other job can catch a broken export map.
+  # The job always runs (so it stays usable as a required check) but does the work only when the
+  # published output could have changed. Within a package it is deliberately unscoped: packing one
+  # package builds its workspace dependencies too, so a change anywhere can break another tarball.
+  publishability:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
+    - uses: jdx/mise-action@v2
+    - name: Detect changes to published output
+      id: changes
+      run: |
+        git fetch --quiet origin "${{ github.base_ref }}"
+        if git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+          | grep -qE '^(packages/|pnpm-lock\.yaml|pnpm-workspace\.yaml|tsup\.config\.ts|package\.json|scripts/checkPublishability\.sh)'; then
+          echo "affected=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "affected=false" >> "$GITHUB_OUTPUT"
+          echo "No changes to published output; skipping." >> "$GITHUB_STEP_SUMMARY"
+        fi
+    - name: Install dependencies
+      if: steps.changes.outputs.affected == 'true'
+      run: pnpm install
+    - name: Check publishability
+      if: steps.changes.outputs.affected == 'true'
+      run: pnpm lint:publish

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,13 @@ on:
     branches:
       - main
 
+# Two merges landing while a release is in flight would otherwise run `changeset publish`
+# concurrently against the registry. Never cancel a run that has started: interrupting a publish
+# mid-flight is how packages end up half-released.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -24,7 +31,8 @@ jobs:
         uses: changesets/action@v1
         with:
           version: pnpm changeset version
-          publish: pnpm changeset publish
+          # `pnpm release` gates `changeset publish` behind publint + attw on the packed tarballs.
+          publish: pnpm release
           commit: "chore(release): version packages"
           title: "chore(release): version packages"
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,13 +26,16 @@ jobs:
           scope: "@sipe-team"
       - name: Install dependencies
         run: pnpm install
+      # A failure here fails the job, so nothing reaches the registry. changesets/action does not
+      # run `publish` through a shell, so the check cannot be chained onto it — it goes before.
+      - name: Check publishability
+        run: pnpm lint:publish
       - name: Create Release Pull Request or Publish to Github Package Registry
         id: changesets
         uses: changesets/action@v1
         with:
           version: pnpm changeset version
-          # `pnpm release` gates `changeset publish` behind publint + attw on the packed tarballs.
-          publish: pnpm release
+          publish: pnpm changeset publish
           commit: "chore(release): version packages"
           title: "chore(release): version packages"
         env:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "lint:biome:fix": "biome check --write",
     "lint:package": "tsx scripts/checkPackageConsistency.ts",
     "lint:publish": "bash scripts/checkPublishability.sh",
-    "release": "pnpm lint:publish && changeset publish",
     "dev:storybook": "pnpm --filter @sipe-team/tokens build && storybook dev -p 6006",
     "build:storybook": "pnpm --filter @sipe-team/tokens build && storybook build",
     "serve:storybook": "npx http-server storybook-static -p 6006",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "lint:biome": "biome lint",
     "lint:biome:fix": "biome check --write",
     "lint:package": "tsx scripts/checkPackageConsistency.ts",
+    "lint:publish": "bash scripts/checkPublishability.sh",
+    "release": "pnpm lint:publish && changeset publish",
     "dev:storybook": "pnpm --filter @sipe-team/tokens build && storybook dev -p 6006",
     "build:storybook": "pnpm --filter @sipe-team/tokens build && storybook build",
     "serve:storybook": "npx http-server storybook-static -p 6006",
@@ -21,6 +23,7 @@
     "clean": "pnpm --filter './www' clean && pnpm --filter './packages/*' clean"
   },
   "devDependencies": {
+    "@arethetypeswrong/cli": "^0.18.5",
     "@biomejs/biome": "^2.4.10",
     "@changesets/cli": "^2.27.9",
     "@clack/prompts": "^0.9.0",
@@ -47,6 +50,7 @@
     "inquirer": "^9.3.8",
     "knip": "catalog:",
     "lint-staged": "^15.3.0",
+    "publint": "^0.3.21",
     "sanitize.css": "^13.0.0",
     "storybook": "catalog:",
     "tsup": "catalog:",

--- a/packages/accordion/tsup.config.ts
+++ b/packages/accordion/tsup.config.ts
@@ -1,8 +1,3 @@
-import { defineConfig } from 'tsup';
+import defaultConfig from '../../tsup.config';
 
-export default defineConfig({
-  entry: ['src/index.ts'],
-  clean: true,
-  dts: true,
-  format: ['esm', 'cjs'],
-});
+export default defaultConfig;

--- a/packages/grid/tsup.config.ts
+++ b/packages/grid/tsup.config.ts
@@ -1,8 +1,3 @@
-import { defineConfig } from 'tsup';
+import defaultConfig from '../../tsup.config';
 
-export default defineConfig({
-  entry: ['src/index.ts'],
-  clean: true,
-  dts: true,
-  format: ['esm', 'cjs'],
-});
+export default defaultConfig;

--- a/packages/reset/package.json
+++ b/packages/reset/package.json
@@ -51,7 +51,7 @@
           "default": "./dist/index.cjs"
         }
       },
-      "./reset.css": "./dist/reset.css"
+      "./reset.css": "./dist/index.css"
     }
   },
   "sideEffects": [

--- a/packages/tokens/config.js
+++ b/packages/tokens/config.js
@@ -285,6 +285,7 @@ console.log('✓ dist/styles.css generated');
 
 // token-names barrel (.js + .d.ts — consumed via publishConfig ./token-names export)
 mkdirSync(DIST_TS, { recursive: true });
+
 writeFileSync(
   `${DIST_TS}/index.js`,
   "/** Auto-generated — do not edit directly. */\nexport * from './primitive.js';\n",
@@ -294,14 +295,21 @@ writeFileSync(
   "/** Auto-generated — do not edit directly. */\n'use strict';\nmodule.exports = require('./primitive.cjs');\n",
 );
 
-const barrelDts = [
-  '/** Auto-generated — do not edit directly. */',
-  "export * from './primitive';",
-  "export * from './semantic';",
-  'export type DesignToken = PrimitiveToken | SemanticToken;',
-  '/** Wraps a design token name in `var()` for use in inline styles. */',
-  'export declare function cssVar<T extends DesignToken>(token: T): `var(--${T})`;\n',
-].join('\n');
-writeFileSync(`${DIST_TS}/index.d.ts`, barrelDts);
-writeFileSync(`${DIST_TS}/index.d.cts`, barrelDts);
+/**
+ * Relative specifiers in declaration files must carry the runtime extension, otherwise node16 ESM
+ * resolution fails to find the sibling modules. The semantic layer is types-only and needs no
+ * runtime module: TypeScript resolves `./semantic.js` to `semantic.d.ts` by extension substitution.
+ * @param {'.js' | '.cjs'} ext
+ */
+const barrelDts = (ext) =>
+  [
+    '/** Auto-generated — do not edit directly. */',
+    `export * from './primitive${ext}';`,
+    `export * from './semantic${ext}';`,
+    'export type DesignToken = PrimitiveToken | SemanticToken;',
+    '/** Wraps a design token name in `var()` for use in inline styles. */',
+    'export declare function cssVar<T extends DesignToken>(token: T): `var(--${T})`;\n',
+  ].join('\n');
+writeFileSync(`${DIST_TS}/index.d.ts`, barrelDts('.js'));
+writeFileSync(`${DIST_TS}/index.d.cts`, barrelDts('.cjs'));
 console.log(`✓ ${DIST_TS}/index.js + index.cjs generated`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
 
   .:
     devDependencies:
+      '@arethetypeswrong/cli':
+        specifier: ^0.18.5
+        version: 0.18.5
       '@biomejs/biome':
         specifier: ^2.4.10
         version: 2.4.10
@@ -168,6 +171,9 @@ importers:
       lint-staged:
         specifier: ^15.3.0
         version: 15.3.0
+      publint:
+        specifier: ^0.3.21
+        version: 0.3.21
       sanitize.css:
         specifier: ^13.0.0
         version: 13.0.0
@@ -1330,6 +1336,18 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
+  '@andrewbranch/untar.js@1.0.3':
+    resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
+
+  '@arethetypeswrong/cli@0.18.5':
+    resolution: {integrity: sha512-gM+8vRsQOD/Uc7EnBedUhkG5OCsDWE4uoak5QvomGpMpaky0Eh41p04nIMgrWb8EOmqZUJGc6zz9hsP6E56R7g==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  '@arethetypeswrong/core@0.18.5':
+    resolution: {integrity: sha512-9ytjzGwxjm9Uz7I9avfbt5vlQt6uk9uRRESzJjqrznl6WKvI6dwYTo+vJ3U02Wrq/mR3iql/PzhvHhKdJIAjDQ==}
+    engines: {node: '>=20'}
+
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
@@ -2027,6 +2045,9 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@braidai/lang@1.1.2':
+    resolution: {integrity: sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==}
 
   '@bundled-es-modules/deepmerge@4.3.1':
     resolution: {integrity: sha512-Rk453EklPUPC3NRWc3VUNI/SSUjdBaFoaQvFRmNBNtMHVtOFD5AntiWg5kEE1hqcPqedYFDzxE3ZcMYPcA195w==}
@@ -3379,6 +3400,9 @@ packages:
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
 
+  '@loaderkit/resolve@1.0.6':
+    resolution: {integrity: sha512-G8FdIoF5CypfwmD9rl8BXod5HDn8JqB0CCNBXDTaRZ+yRYhARrrSToX1zg1zy9jX3zLqigsELwhT4gNtkdQAUg==}
+
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
 
@@ -3445,6 +3469,10 @@ packages:
 
   '@polka/url@1.0.0-next.28':
     resolution: {integrity: sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==}
+
+  '@publint/pack@0.1.5':
+    resolution: {integrity: sha512-edgyN2pP07uXiP4tJs0s8KVmU8M8i60YPbbI0/WDeok1mIJHRXz+CgD8I0nelwDkoCh3EWL/G5kGfbuHjsdbvw==}
+    engines: {node: '>=18'}
 
   '@radix-ui/react-compose-refs@1.1.0':
     resolution: {integrity: sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==}
@@ -4849,6 +4877,9 @@ packages:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
 
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
   clean-css@5.3.3:
     resolution: {integrity: sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==}
     engines: {node: '>= 10.0'}
@@ -4868,6 +4899,11 @@ packages:
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
+
+  cli-highlight@2.1.11:
+    resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
+    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
+    hasBin: true
 
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
@@ -4893,6 +4929,9 @@ packages:
     resolution: {integrity: sha512-CXkMQxU6s9GklO/1f714dkKBMu1lopS1WFF0B8o4AxPykR1hpozxSiUZ5ZUeBjfPgCWqbcNOtZVFhB8Lkfp1+Q==}
     peerDependencies:
       typanion: '*'
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -5776,6 +5815,9 @@ packages:
     resolution: {integrity: sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==}
     engines: {node: '>=0.4.0'}
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
@@ -6124,6 +6166,9 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
   history@4.10.1:
     resolution: {integrity: sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==}
@@ -6910,6 +6955,17 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
+  marked-terminal@7.3.0:
+    resolution: {integrity: sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      marked: '>=1 <16'
+
+  marked@9.1.6:
+    resolution: {integrity: sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==}
+    engines: {node: '>= 16'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -7466,6 +7522,9 @@ packages:
   package-manager-detector@0.2.7:
     resolution: {integrity: sha512-g4+387DXDKlZzHkP+9FLt8yKj8+/3tOkPv7DVTJGGRm00RkEWgqbFstX1mXJ4M0VDYhUqsTOiISqNOJnhAu3PQ==}
 
+  package-manager-detector@1.7.0:
+    resolution: {integrity: sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==}
+
   param-case@3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
 
@@ -7491,8 +7550,17 @@ packages:
     resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
     engines: {node: '>=0.10.0'}
 
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
+
   parse5-htmlparser2-tree-adapter@7.1.0:
     resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5@5.1.1:
+    resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
+
+  parse5@6.0.1:
+    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
   parse5@7.2.1:
     resolution: {integrity: sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==}
@@ -8096,6 +8164,11 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  publint@0.3.21:
+    resolution: {integrity: sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   punycode@1.4.1:
     resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
 
@@ -8454,6 +8527,10 @@ packages:
 
   rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
 
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -8821,6 +8898,10 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
+  supports-hyperlinks@3.2.0:
+    resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
+    engines: {node: '>=14.18'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -8915,6 +8996,10 @@ packages:
 
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.16:
@@ -9052,6 +9137,11 @@ packages:
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
 
+  typescript@5.6.1-rc:
+    resolution: {integrity: sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@5.6.3:
     resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
     engines: {node: '>=14.17'}
@@ -9179,6 +9269,10 @@ packages:
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
+
+  validate-npm-package-name@5.0.1:
+    resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   value-equal@1.0.1:
     resolution: {integrity: sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==}
@@ -9516,9 +9610,17 @@ packages:
     engines: {node: '>= 14'}
     hasBin: true
 
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+
+  yargs@16.2.2:
+    resolution: {integrity: sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==}
+    engines: {node: '>=10'}
 
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
@@ -9742,6 +9844,29 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
+
+  '@andrewbranch/untar.js@1.0.3': {}
+
+  '@arethetypeswrong/cli@0.18.5':
+    dependencies:
+      '@arethetypeswrong/core': 0.18.5
+      chalk: 4.1.2
+      cli-table3: 0.6.5
+      commander: 10.0.1
+      marked: 9.1.6
+      marked-terminal: 7.3.0(marked@9.1.6)
+      semver: 7.7.4
+
+  '@arethetypeswrong/core@0.18.5':
+    dependencies:
+      '@andrewbranch/untar.js': 1.0.3
+      '@loaderkit/resolve': 1.0.6
+      cjs-module-lexer: 1.4.3
+      fflate: 0.8.3
+      lru-cache: 11.3.5
+      semver: 7.7.4
+      typescript: 5.6.1-rc
+      validate-npm-package-name: 5.0.1
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -10638,6 +10763,8 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.10':
     optional: true
 
+  '@braidai/lang@1.1.2': {}
+
   '@bundled-es-modules/deepmerge@4.3.1':
     dependencies:
       deepmerge: 4.3.1
@@ -10998,7 +11125,7 @@ snapshots:
     dependencies:
       '@simple-libs/child-process-utils': 1.0.2
       '@simple-libs/stream-utils': 1.2.0
-      semver: 7.6.3
+      semver: 7.7.4
     optionalDependencies:
       conventional-commits-parser: 6.4.0
 
@@ -12569,6 +12696,10 @@ snapshots:
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
+  '@loaderkit/resolve@1.0.6':
+    dependencies:
+      '@braidai/lang': 1.1.2
+
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.26.0
@@ -12673,6 +12804,10 @@ snapshots:
       config-chain: 1.1.13
 
   '@polka/url@1.0.0-next.28': {}
+
+  '@publint/pack@0.1.5':
+    dependencies:
+      tinyexec: 1.2.4
 
   '@radix-ui/react-compose-refs@1.1.0(@types/react@18.3.13)(react@18.3.1)':
     dependencies:
@@ -14233,6 +14368,8 @@ snapshots:
 
   ci-info@3.9.0: {}
 
+  cjs-module-lexer@1.4.3: {}
+
   clean-css@5.3.3:
     dependencies:
       source-map: 0.6.1
@@ -14248,6 +14385,15 @@ snapshots:
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
+
+  cli-highlight@2.1.11:
+    dependencies:
+      chalk: 4.1.2
+      highlight.js: 10.7.3
+      mz: 2.7.0
+      parse5: 5.1.1
+      parse5-htmlparser2-tree-adapter: 6.0.1
+      yargs: 16.2.2
 
   cli-spinners@2.9.2: {}
 
@@ -14269,6 +14415,12 @@ snapshots:
   clipanion@4.0.0-rc.4(typanion@3.14.0):
     dependencies:
       typanion: 3.14.0
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   cliui@8.0.1:
     dependencies:
@@ -14529,7 +14681,7 @@ snapshots:
       postcss-modules-scope: 3.2.1(postcss@8.4.49)
       postcss-modules-values: 4.0.0(postcss@8.4.49)
       postcss-value-parser: 4.2.0
-      semver: 7.6.3
+      semver: 7.7.4
     optionalDependencies:
       webpack: 5.97.1(esbuild@0.27.7)
 
@@ -15291,6 +15443,8 @@ snapshots:
     dependencies:
       xml-js: 1.6.11
 
+  fflate@0.8.3: {}
+
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -15403,7 +15557,7 @@ snapshots:
       memfs: 3.5.3
       minimatch: 3.1.2
       schema-utils: 2.7.0
-      semver: 7.6.3
+      semver: 7.7.4
       tapable: 1.1.3
       typescript: 5.6.3
       webpack: 5.97.1(esbuild@0.27.7)
@@ -15746,6 +15900,8 @@ snapshots:
       space-separated-tokens: 2.0.2
 
   he@1.2.0: {}
+
+  highlight.js@10.7.3: {}
 
   history@4.10.1:
     dependencies:
@@ -16520,6 +16676,19 @@ snapshots:
       repeat-string: 1.6.1
 
   markdown-table@3.0.4: {}
+
+  marked-terminal@7.3.0(marked@9.1.6):
+    dependencies:
+      ansi-escapes: 7.0.0
+      ansi-regex: 6.1.0
+      chalk: 5.4.1
+      cli-highlight: 2.1.11
+      cli-table3: 0.6.5
+      marked: 9.1.6
+      node-emoji: 2.2.0
+      supports-hyperlinks: 3.2.0
+
+  marked@9.1.6: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -17343,9 +17512,11 @@ snapshots:
       got: 12.6.1
       registry-auth-token: 5.0.3
       registry-url: 6.0.1
-      semver: 7.6.3
+      semver: 7.7.4
 
   package-manager-detector@0.2.7: {}
+
+  package-manager-detector@1.7.0: {}
 
   param-case@3.0.4:
     dependencies:
@@ -17379,10 +17550,18 @@ snapshots:
 
   parse-passwd@1.0.0: {}
 
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    dependencies:
+      parse5: 6.0.1
+
   parse5-htmlparser2-tree-adapter@7.1.0:
     dependencies:
       domhandler: 5.0.3
       parse5: 7.2.1
+
+  parse5@5.1.1: {}
+
+  parse5@6.0.1: {}
 
   parse5@7.2.1:
     dependencies:
@@ -17634,7 +17813,7 @@ snapshots:
       cosmiconfig: 8.3.6(typescript@5.6.3)
       jiti: 1.21.7
       postcss: 8.4.49
-      semver: 7.6.3
+      semver: 7.7.4
       webpack: 5.97.1(esbuild@0.27.7)
     transitivePeerDependencies:
       - typescript
@@ -17983,6 +18162,13 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  publint@0.3.21:
+    dependencies:
+      '@publint/pack': 0.1.5
+      package-manager-detector: 1.7.0
+      picocolors: 1.1.1
+      sade: 1.8.1
 
   punycode@1.4.1: {}
 
@@ -18519,6 +18705,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
+
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
@@ -18573,7 +18763,7 @@ snapshots:
 
   semver-diff@4.0.0:
     dependencies:
-      semver: 7.6.3
+      semver: 7.7.4
 
   semver@6.3.1: {}
 
@@ -18953,6 +19143,11 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-hyperlinks@3.2.0:
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
+
   supports-preserve-symlinks-flag@1.0.0: {}
 
   svg-parser@2.0.4: {}
@@ -19031,6 +19226,8 @@ snapshots:
   tinyexec@0.3.2: {}
 
   tinyexec@1.1.1: {}
+
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.16:
     dependencies:
@@ -19156,6 +19353,8 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
+  typescript@5.6.1-rc: {}
+
   typescript@5.6.3: {}
 
   ufo@1.6.3: {}
@@ -19248,7 +19447,7 @@ snapshots:
       is-yarn-global: 0.4.1
       latest-version: 7.0.0
       pupa: 3.1.0
-      semver: 7.6.3
+      semver: 7.7.4
       semver-diff: 4.0.0
       xdg-basedir: 5.1.0
 
@@ -19295,6 +19494,8 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@8.3.2: {}
+
+  validate-npm-package-name@5.0.1: {}
 
   value-equal@1.0.1: {}
 
@@ -19680,7 +19881,19 @@ snapshots:
 
   yaml@2.6.1: {}
 
+  yargs-parser@20.2.9: {}
+
   yargs-parser@21.1.1: {}
+
+  yargs@16.2.2:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
 
   yargs@17.7.2:
     dependencies:

--- a/scripts/checkPublishability.sh
+++ b/scripts/checkPublishability.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Packages point `exports` at `src/` and swap it for `dist/` via `publishConfig.exports`, a
+# pnpm-only behaviour. The published export map is therefore never exercised by a local build,
+# typecheck, or test run. Pack every package and validate the resulting tarball — the same bytes
+# the registry receives. `pack` runs each `prepack` (i.e. `tsup`), so this also proves they build.
+#
+# attw is given the CSS subpaths to skip, since stylesheets carry no type declarations; it ignores
+# the ones a package does not export. publint still proves every stylesheet is in the tarball.
+
+set -uo pipefail
+
+dir=$(mktemp -d)
+trap 'rm -rf "$dir"' EXIT
+
+pnpm --filter './packages/*' --recursive pack --pack-destination "$dir" > /dev/null || exit 1
+
+status=0
+for tarball in "$dir"/*.tgz; do
+  pnpm exec publint run "$tarball" --level warning --strict || status=1
+  pnpm exec attw "$tarball" --profile node16 --exclude-entrypoints ./styles.css ./reset.css || status=1
+done
+
+exit $status


### PR DESCRIPTION
## Changes

배포되는 export map이 실제로 해석되는지 검증하는 게이트를 추가하고, 그 게이트가 잡아낸 결함 4건을 고칩니다.

### 왜 필요한가

각 패키지는 워크스페이스 소비자를 위해 `exports`로 `src/`를 가리키고, 배포 시점에 `publishConfig.exports`로 `dist/`로 치환됩니다. **이 치환은 pnpm 전용 동작**이라, 실제로 배포되는 export map은 `pnpm build`·`pnpm typecheck`·`pnpm test`·Storybook·www 빌드 중 **어느 것으로도 검증되지 않습니다.** 소비자가 설치하고 나서야 깨진 걸 압니다.

실제로 이미 4개 패키지가 깨진 상태로 배포되고 있었습니다.

### 게이트

`scripts/checkPublishability.sh` (12줄)가 워크스페이스 전체를 `pnpm pack`한 뒤, tarball마다 `publint`와 `attw`를 돌립니다.

| 결함 | publint | attw |
|---|:---:|:---:|
| export가 없는 파일을 가리킴 | ✅ | ❌ |
| `require.types`가 ESM `.d.ts`를 가리킴 (masquerading) | ❌ | ✅ |


### 잡아낸 결함 4건

| 패키지 | 결함 | 영향 |
|---|---|---|
| `accordion`, `grid` | 로컬 `tsup.config.ts`에 **vanilla-extract 플러그인이 누락**되어 `.css.ts`가 컴파일조차 안 됨 | `dist/index.css`가 tarball에 없음 → **두 컴포넌트가 스타일 없이 배포되고 있었음** |
| `reset` | export가 `./dist/reset.css`를 가리키는데 빌드 산출물은 `./dist/index.css` | `@sipe-team/reset/reset.css` import 해석 실패 |
| `tokens` | 생성되는 barrel 선언이 확장자 없이 형제 모듈 참조 (`export * from './primitive'`) | `@sipe-team/tokens/token-names`가 node16 ESM에서 타입 해석 실패 |

accordion·grid는 다른 패키지들이 쓰던 대로 루트 tsup 설정을 재사용하도록 되돌렸습니다.


## Checklist

- [x] Have you written the functional specifications?
