### PR TITLE
fix(accordion,grid): inherit the root tsup config so vanilla-extract runs

### DIFF
--- a/.changeset/fix-accordion-vanilla-extract.md
+++ b/.changeset/fix-accordion-vanilla-extract.md
@@ -1,0 +1,18 @@
+---
+'@sipe-team/accordion': patch
+---
+
+Fix the missing vanilla-extract build plugin.
+
+`packages/accordion/tsup.config.ts` did not inherit the root tsup config, so the vanilla-extract esbuild plugin never ran for it. This is a residual case of the same defect #291 fixed for `@sipe-team/tokens`.
+
+As a result:
+
+- `Accordion.css.ts` bundled as ordinary TypeScript, so importing `dist` threw at runtime (`Styles were unable to be assigned to a file`).
+- `dist/index.css` was never emitted, so the `./styles.css` entrypoint advertised by `publishConfig` pointed at a file that did not exist. Consumers importing `@sipe-team/accordion/styles.css` got `ERR_MODULE_NOT_FOUND`.
+
+**Changes**
+
+- `tsup.config.ts` now inherits the root config (the same pattern as the other 15 packages).
+
+`publishConfig.exports` and `sideEffects` were already declared correctly and are left untouched — they simply start being honoured.

--- a/.changeset/fix-grid-vanilla-extract.md
+++ b/.changeset/fix-grid-vanilla-extract.md
@@ -1,0 +1,18 @@
+---
+'@sipe-team/grid': patch
+---
+
+Fix the missing vanilla-extract build plugin.
+
+`packages/grid/tsup.config.ts` did not inherit the root tsup config, so the vanilla-extract esbuild plugin never ran for it. This is a residual case of the same defect #291 fixed for `@sipe-team/tokens`.
+
+As a result:
+
+- `Grid.css.ts` bundled as ordinary TypeScript, so importing `dist` threw at runtime (`Styles were unable to be assigned to a file`).
+- `dist/index.css` was never emitted, so the `./styles.css` entrypoint advertised by `publishConfig` pointed at a file that did not exist. Consumers importing `@sipe-team/grid/styles.css` got `ERR_MODULE_NOT_FOUND`.
+
+**Changes**
+
+- `tsup.config.ts` now inherits the root config (the same pattern as the other 15 packages).
+
+`publishConfig.exports` and `sideEffects` were already declared correctly and are left untouched — they simply start being honoured.

--- a/packages/accordion/tsup.config.ts
+++ b/packages/accordion/tsup.config.ts
@@ -1,8 +1,3 @@
-import { defineConfig } from 'tsup';
+import defaultConfig from '../../tsup.config';
 
-export default defineConfig({
-  entry: ['src/index.ts'],
-  clean: true,
-  dts: true,
-  format: ['esm', 'cjs'],
-});
+export default defaultConfig;

--- a/packages/grid/tsup.config.ts
+++ b/packages/grid/tsup.config.ts
@@ -1,8 +1,3 @@
-import { defineConfig } from 'tsup';
+import defaultConfig from '../../tsup.config';
 
-export default defineConfig({
-  entry: ['src/index.ts'],
-  clean: true,
-  dts: true,
-  format: ['esm', 'cjs'],
-});
+export default defaultConfig;


### PR DESCRIPTION
## Changes

`@sipe-team/accordion`과 `@sipe-team/grid`는 `.css.ts`(vanilla-extract) 스타일을 쓰는 17개 패키지 중, tsup 설정이 루트 설정을 상속하지 않는 **마지막 2개**였습니다. 그 결과 vanilla-extract esbuild 플러그인이 이 둘에서만 실행되지 않았고, 다음 문제가 있었습니다:

- `Accordion.css.ts` / `Grid.css.ts`가 일반 TypeScript로 번들되어, `dist`를 import하면 **런타임에 예외가 발생**합니다 (`Styles were unable to be assigned to a file`).
- `dist/index.css`가 생성되지 않아, 두 패키지의 `publishConfig`가 이미 광고하고 있는 `"./styles.css": "./dist/index.css"` 진입점이 **존재하지 않는 파일을 가리키고** 있었습니다. 소비자의 `import '@sipe-team/accordion/styles.css'`는 `ERR_MODULE_NOT_FOUND`로 실패합니다.

이는 #291이 `@sipe-team/tokens`에서 고친 것과 **동일한 결함의 잔여 케이스**입니다. (#291의 changeset은 "tokens가 유일하게 루트 설정을 상속하지 않았다"고 기술했으나, 실제로는 accordion·grid가 같은 상태로 남아 있었습니다.)

**변경 사항**

- `packages/accordion/tsup.config.ts` — 루트 설정 상속으로 교체 (다른 15개 패키지와 동일한 `import defaultConfig from '../../tsup.config'` 패턴)
- `packages/grid/tsup.config.ts` — 동일
- changeset 2개 추가 (accordion `patch`, grid `patch` — 패키지별 분리)

`publishConfig.exports`와 `sideEffects: ["**/*.css"]`는 이미 올바르게 선언돼 있어 건드리지 않았습니다 — 이제서야 그 선언이 지켜집니다.

## Visuals

없음 (빌드 설정 변경).

빌드 산출물 before/after:

| | `dist/index.css` | `dist/index.js`의 VE 런타임 import |
|---|---|---|
| 수정 전 (dev) | ❌ 생성 안 됨 | `@vanilla-extract/css` 잔존 (런타임 throw) |
| 수정 후 | ✅ accordion 1,882B / grid 1,830B | 0건 (빌드타임 컴파일) |

## Checklist
- [x] Have you written the functional specifications?  — 배포 버그 수정. changeset 2개에 상세 기술
