### PR TITLE
fix(changeset): Remove non-existent package from changeset to unblock release CI

### DIFF
--- a/.changeset/package-json-divergence-cleanup.md
+++ b/.changeset/package-json-divergence-cleanup.md
@@ -3,7 +3,6 @@
 "@sipe-team/avatar": patch
 "@sipe-team/checkbox": patch
 "@sipe-team/divider": patch
-"@sipe-team/plugin-figma-codegen": patch
 "@sipe-team/radio": patch
 "@sipe-team/side": patch
 "@sipe-team/switch": patch


### PR DESCRIPTION
## Summary

Release CI is failing because `package-json-divergence-cleanup` changeset references `@sipe-team/plugin-figma-codegen`, which no longer exists in the workspace. Removes the stale entry to unblock the release pipeline.

## Changes

- Remove `@sipe-team/plugin-figma-codegen` from `.changeset/package-json-divergence-cleanup.md`