### PR TITLE
docs(www): document Typography

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1193,6 +1193,9 @@ importers:
       '@sipe-team/tokens':
         specifier: workspace:*
         version: link:../packages/tokens
+      '@sipe-team/typography':
+        specifier: workspace:*
+        version: link:../packages/typography
       clsx:
         specifier: ^2.0.0
         version: 2.1.1

--- a/www/docs/components/_TEMPLATE.md
+++ b/www/docs/components/_TEMPLATE.md
@@ -47,8 +47,10 @@ sidebar_label: ComponentName
         <Thing variant="fill">Hello</Thing>
       </Preview>
 
-  A workspace package must be aliased to its `dist` build in `www/docusaurus.config.ts`, and its
-  stylesheet added to `customCss` there, before it can be used on a docs page.
+  To use a component on a docs page, add its workspace package to `www/package.json` dependencies
+  and import it in the MDX. The `side-vanilla-extract` webpack plugin compiles the package's
+  `.css.ts` straight from source, so no dist alias or `customCss` entry is needed. (Only
+  `@sipe-team/tokens` is special-cased in `docusaurus.config.ts`, for its Style Dictionary layer.)
 -->
 
 # ComponentName

--- a/www/docs/components/typography.mdx
+++ b/www/docs/components/typography.mdx
@@ -1,0 +1,156 @@
+---
+sidebar_label: Typography
+---
+
+import { Typography } from '@sipe-team/typography';
+
+# Typography
+
+The text primitive that renders body copy at the design system's font sizes, weights, and line
+heights.
+
+## Installation
+
+```sh
+npm install @sipe-team/typography
+```
+
+```ts
+import '@sipe-team/typography/styles.css';
+```
+
+## Usage
+
+Renders a paragraph at the default scale (`size={14}`, `weight="regular"`, `lineHeight="regular"`).
+
+<Preview
+  code={`<Typography>The quick brown fox jumps over the lazy dog.</Typography>`}
+>
+  <Typography>The quick brown fox jumps over the lazy dog.</Typography>
+</Preview>
+
+## Examples
+
+### Size
+
+`size` maps to the token scale in pixels — from `12` for fine print up to `48` for display text.
+Pick the step that matches the role of the text, not an arbitrary pixel value.
+
+<Preview
+  code={`<Typography size={12}>Caption · 12</Typography>
+<Typography size={16}>Body · 16</Typography>
+<Typography size={24}>Heading · 24</Typography>
+<Typography size={48}>Display · 48</Typography>`}
+>
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+    <Typography size={12}>Caption · 12</Typography>
+    <Typography size={16}>Body · 16</Typography>
+    <Typography size={24}>Heading · 24</Typography>
+    <Typography size={48}>Display · 48</Typography>
+  </div>
+</Preview>
+
+### Weight
+
+`weight` selects the font weight by name. Reach for `medium` or heavier to signal emphasis or
+hierarchy; keep long-form reading text at `regular`.
+
+<Preview
+  code={`<Typography size={20} weight="regular">Regular · 400</Typography>
+<Typography size={20} weight="medium">Medium · 500</Typography>
+<Typography size={20} weight="semiBold">SemiBold · 600</Typography>
+<Typography size={20} weight="bold">Bold · 700</Typography>`}
+>
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+    <Typography size={20} weight="regular">Regular · 400</Typography>
+    <Typography size={20} weight="medium">Medium · 500</Typography>
+    <Typography size={20} weight="semiBold">SemiBold · 600</Typography>
+    <Typography size={20} weight="bold">Bold · 700</Typography>
+  </div>
+</Preview>
+
+### Line height
+
+`lineHeight` trades vertical density for readability. Use `regular` (1.5) for paragraphs a reader
+scans line by line, and `compact` (1.3) for tight, single-purpose labels or headings.
+
+<Preview
+  code={`<Typography lineHeight="regular">
+  Regular line height gives paragraphs room to breathe across multiple lines.
+</Typography>
+<Typography lineHeight="compact">
+  Compact line height pulls the lines together for dense, glanceable text.
+</Typography>`}
+>
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', maxWidth: '32ch' }}>
+    <Typography lineHeight="regular">
+      Regular line height gives paragraphs room to breathe across multiple lines.
+    </Typography>
+    <Typography lineHeight="compact">
+      Compact line height pulls the lines together for dense, glanceable text.
+    </Typography>
+  </div>
+</Preview>
+
+### Color
+
+`color` takes any CSS color string and is applied to the text. Left unset, the text inherits its
+color from the surrounding context.
+
+<Preview
+  code={`<Typography color="#3b82f6">A blue line of text</Typography>
+<Typography color="tomato">A tomato line of text</Typography>`}
+>
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+    <Typography color="#3b82f6">A blue line of text</Typography>
+    <Typography color="tomato">A tomato line of text</Typography>
+  </div>
+</Preview>
+
+### `asChild`
+
+Merge the typography styles onto a different element instead of the default `p` — useful for a
+heading tag or a link that should carry the same scale. `size` and `weight` are visual only: a
+large `<p>` is not a heading, so reach for `asChild` with a real `<h1>`–`<h6>` when the text is
+structural, or screen readers and the document outline won't see it.
+
+<Preview
+  code={`<Typography asChild size={24} weight="bold">
+  <h2>A styled heading element</h2>
+</Typography>`}
+>
+  <Typography asChild size={24} weight="bold">
+    <h2 style={{ margin: 0 }}>A styled heading element</h2>
+  </Typography>
+</Preview>
+
+## Anatomy
+
+```tsx
+import { Typography } from '@sipe-team/typography';
+
+export default () => (
+  <Typography size={16} weight="medium" lineHeight="regular">
+    Label
+  </Typography>
+);
+```
+
+Renders a single `<p>` by default. With `asChild`, the styles and props are merged onto the child
+element you provide instead.
+
+## API Reference
+
+Renders a `<p>` and forwards its `ref`.
+
+| Prop         | Type                                                          | Default       | Description                                              |
+| ------------ | ------------------------------------------------------------ | ------------- | ------------------------------------------------------- |
+| `children`   | `ReactNode`                                                  | —             | The text content.                                       |
+| `size`       | `12 \| 14 \| 16 \| 18 \| 20 \| 24 \| 28 \| 32 \| 36 \| 48`   | `14`          | Font size in pixels, from the token scale.              |
+| `weight`     | `'regular' \| 'medium' \| 'semiBold' \| 'bold'`             | `'regular'`   | Font weight (400 / 500 / 600 / 700).                    |
+| `lineHeight` | `'regular' \| 'compact'`                                     | `'regular'`   | Line height — `regular` is 1.5, `compact` is 1.3.       |
+| `color`      | `string`                                                    | —             | Any CSS color. Unset, the text inherits its color.      |
+| `asChild`    | `boolean`                                                    | `false`       | Merge props onto the child instead of rendering a `p`.  |
+
+Also accepts every `ComponentProps<'p'>` except `color` (which is overridden above), forwarded to
+the rendered element.

--- a/www/package.json
+++ b/www/package.json
@@ -24,6 +24,7 @@
     "@sipe-team/button": "workspace:*",
     "@sipe-team/icon": "workspace:*",
     "@sipe-team/tokens": "workspace:*",
+    "@sipe-team/typography": "workspace:*",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
     "react": "catalog:react",


### PR DESCRIPTION
## Changes

Typography를 문서로 추가합니다. 컴포넌트 변경 없이 문서만 추가하는 PR입니다.

**`typography.mdx`**
- Installation / Usage / Examples / Anatomy / API Reference. API 표는 소스를 직접 읽고 수동 작성.
- size · weight · color 예제. weight 예제 코드는 라이브 데모와 일치시켰습니다.
- `asChild`에 시맨틱 노트 추가: size/weight는 시각 표현일 뿐이므로, 실제 문서 구조가 필요하면 진짜 `<h1>`–`<h6>`와 함께 `asChild`를 쓰라고 안내합니다.

**`_TEMPLATE.md`** — 낡은 dist-alias 설명을 소스 컴파일 설명으로 갱신.

## Visuals
<img width="1302" height="1171" alt="스크린샷 2026-07-21 오후 9 56 19" src="https://github.com/user-attachments/assets/9d8d7812-af3a-492b-918a-d92e1354e973" />



## Checklist
- [x] Have you written the functional specifications? — 문서 자체가 명세
- [ ] Have you written the test code? — 문서 전용 PR이라 유닛 테스트 없음. 프로덕션 빌드로 검증

## Additional Discussion Points
- None
