### PR TITLE
docs(www): document Checkbox (+ fix inline SVG assets and defaultChecked warning)

### DIFF
--- a/.changeset/fix-checkbox-assets-and-controlled.md
+++ b/.changeset/fix-checkbox-assets-and-controlled.md
@@ -1,0 +1,8 @@
+---
+"@sipe-team/checkbox": patch
+---
+
+Fix two issues.
+
+- **SVG assets**: `Checkbox.css.ts` referenced `url("public/check.svg")` / `url("public/indeterminate.svg")`, which esbuild (tsup) resolved but source-compiling consumers (webpack + `@vanilla-extract/webpack-plugin`, e.g. the Docusaurus docs site) could not, breaking their production build. The icons are now inlined as `data:` URIs so both bundlers render identical marks with no external asset resolution.
+- **`checked` + `defaultChecked` warning**: `Root` did not consume `defaultChecked`, so it leaked through context onto the `<input>` alongside the always-set `checked`, triggering React's "input with both checked and defaultChecked" warning. `Root` now destructures `defaultChecked` (it only seeds the uncontrolled initial state), so the input receives just `checked`.

--- a/packages/checkbox/src/Checkbox.css.ts
+++ b/packages/checkbox/src/Checkbox.css.ts
@@ -38,6 +38,13 @@ const COLORS = {
   hover: color.gray100 || '#F3F4F6',
 };
 
+// SVG 애셋을 data-URI로 인라인해 esbuild(tsup)와 webpack(docs) 양쪽 번들러에서
+// 외부 경로 해석 없이 동일하게 동작하도록 한다.
+const CHECK_ICON_URL =
+  "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='white'%3E%20%3Cpath%20d='M9%2016.17L4.83%2012l-1.42%201.41L9%2019%2021%207l-1.41-1.41L9%2016.17z'/%3E%20%3C/svg%3E";
+const INDETERMINATE_ICON_URL =
+  "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='white'%3E%20%3Cpath%20d='M19%2013H5v-2h14v2z'/%3E%20%3C/svg%3E";
+
 const CHECKBOX_STYLE = {
   borderRadius: BORDER_RADIUS_PX,
   borderWidth: BORDER_WIDTH_PX,
@@ -118,14 +125,14 @@ export const input = recipe({
       true: {
         backgroundColor: CHECKBOX_STYLE.checkedColor,
         borderColor: CHECKBOX_STYLE.checkedColor,
-        backgroundImage: `url("public/check.svg")`,
+        backgroundImage: `url("${CHECK_ICON_URL}")`,
       },
     },
     indeterminate: {
       true: {
         backgroundColor: CHECKBOX_STYLE.checkedColor,
         borderColor: CHECKBOX_STYLE.checkedColor,
-        backgroundImage: `url("public/indeterminate.svg")`,
+        backgroundImage: `url("${INDETERMINATE_ICON_URL}")`,
       },
     },
     disabled: {
@@ -146,7 +153,7 @@ export const input = recipe({
       style: {
         backgroundColor: CHECKBOX_STYLE.disabledColor,
         borderColor: CHECKBOX_STYLE.disabledColor,
-        backgroundImage: `url("public/check.svg")`,
+        backgroundImage: `url("${CHECK_ICON_URL}")`,
         opacity: 0.6,
       },
     },
@@ -158,7 +165,7 @@ export const input = recipe({
       style: {
         backgroundColor: CHECKBOX_STYLE.disabledColor,
         borderColor: CHECKBOX_STYLE.disabledColor,
-        backgroundImage: `url("public/indeterminate.svg")`,
+        backgroundImage: `url("${INDETERMINATE_ICON_URL}")`,
         opacity: 0.6,
       },
     },

--- a/packages/checkbox/src/Checkbox.css.ts
+++ b/packages/checkbox/src/Checkbox.css.ts
@@ -38,12 +38,18 @@ const COLORS = {
   hover: color.gray100 || '#F3F4F6',
 };
 
-// SVG 애셋을 data-URI로 인라인해 esbuild(tsup)와 webpack(docs) 양쪽 번들러에서
-// 외부 경로 해석 없이 동일하게 동작하도록 한다.
-const CHECK_ICON_URL =
-  "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='white'%3E%20%3Cpath%20d='M9%2016.17L4.83%2012l-1.42%201.41L9%2019%2021%207l-1.41-1.41L9%2016.17z'/%3E%20%3C/svg%3E";
-const INDETERMINATE_ICON_URL =
-  "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='white'%3E%20%3Cpath%20d='M19%2013H5v-2h14v2z'/%3E%20%3C/svg%3E";
+// 체크 마크는 <input> 자체의 background-image로 얹히므로(자식을 넣을 수 없는 void 요소)
+// SVG를 data-URI로 인라인한다. 이렇게 하면 esbuild(tsup)와 webpack(docs) 양쪽 번들러가
+// 외부 경로 해석 없이 동일하게 렌더한다. 마크업은 읽고 수정할 수 있게 그대로 두고,
+// 빌드타임에 vanilla-extract가 .css.ts를 평가할 때 encodeURIComponent로 인코딩한다.
+const svgToDataUri = (svg: string) => `data:image/svg+xml,${encodeURIComponent(svg)}`;
+
+const CHECK_ICON_URL = svgToDataUri(
+  `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='white'><path d='M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z'/></svg>`,
+);
+const INDETERMINATE_ICON_URL = svgToDataUri(
+  `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='white'><path d='M19 13H5v-2h14v2z'/></svg>`,
+);
 
 const CHECKBOX_STYLE = {
   borderRadius: BORDER_RADIUS_PX,

--- a/packages/checkbox/src/Checkbox.tsx
+++ b/packages/checkbox/src/Checkbox.tsx
@@ -49,6 +49,7 @@ const Root = forwardRef<HTMLInputElement, CheckBoxRootBaseProps>(
       children,
       style,
       checked,
+      defaultChecked,
       ...props
     },
     ref,
@@ -58,7 +59,7 @@ const Root = forwardRef<HTMLInputElement, CheckBoxRootBaseProps>(
 
     const [checkedState, setCheckedState] = useControllableState<boolean | undefined>({
       prop: checked,
-      defaultProp: props.defaultChecked || false,
+      defaultProp: defaultChecked || false,
       onChange: onCheckedChange || (() => {}),
     });
 

--- a/packages/checkbox/src/public/check.svg
+++ b/packages/checkbox/src/public/check.svg
@@ -1,3 +1,0 @@
-<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='white'>
-  <path d='M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z'/>
-</svg>

--- a/packages/checkbox/src/public/indeterminate.svg
+++ b/packages/checkbox/src/public/indeterminate.svg
@@ -1,3 +1,0 @@
-<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='white'>
-  <path d='M19 13H5v-2h14v2z'/>
-</svg>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1187,6 +1187,9 @@ importers:
       '@sipe-team/button':
         specifier: workspace:*
         version: link:../packages/button
+      '@sipe-team/checkbox':
+        specifier: workspace:*
+        version: link:../packages/checkbox
       '@sipe-team/icon':
         specifier: workspace:*
         version: link:../packages/icon

--- a/www/docs/components/checkbox.mdx
+++ b/www/docs/components/checkbox.mdx
@@ -1,0 +1,239 @@
+---
+sidebar_label: Checkbox
+---
+
+import { useState } from 'react';
+import { Checkbox } from '@sipe-team/checkbox';
+
+export const ControlledCheckbox = () => {
+  const [checked, setChecked] = useState(true);
+  return (
+    <Checkbox.Root checked={checked} onCheckedChange={setChecked}>
+      <Checkbox.Input />
+      <Checkbox.Label>Subscribe to updates ({checked ? 'on' : 'off'})</Checkbox.Label>
+    </Checkbox.Root>
+  );
+};
+
+# Checkbox
+
+A compound checkbox — a `Root` that owns the checked state, wrapping an `Input` and a `Label`.
+
+## Installation
+
+```sh
+npm install @sipe-team/checkbox
+```
+
+```ts
+import '@sipe-team/checkbox/styles.css';
+```
+
+## Usage
+
+`Root` generates one `id` and shares it, so `Input` and `Label` are wired together automatically —
+clicking the label toggles the box.
+
+<Preview
+  code={`<Checkbox.Root defaultChecked>
+  <Checkbox.Input />
+  <Checkbox.Label>Accept the terms</Checkbox.Label>
+</Checkbox.Root>`}
+>
+  <Checkbox.Root defaultChecked>
+    <Checkbox.Input />
+    <Checkbox.Label>Accept the terms</Checkbox.Label>
+  </Checkbox.Root>
+</Preview>
+
+## Examples
+
+### Uncontrolled
+
+Give `Root` a `defaultChecked` and let it track the state itself — the common case for forms that
+read the value on submit.
+
+<Preview
+  code={`<Checkbox.Root defaultChecked>
+  <Checkbox.Input />
+  <Checkbox.Label>Remember me</Checkbox.Label>
+</Checkbox.Root>`}
+>
+  <Checkbox.Root defaultChecked>
+    <Checkbox.Input />
+    <Checkbox.Label>Remember me</Checkbox.Label>
+  </Checkbox.Root>
+</Preview>
+
+### Controlled
+
+Own the state yourself with `checked` and `onCheckedChange` when another part of the UI has to
+react to it. `onCheckedChange` receives the next boolean.
+
+<Preview
+  code={`const [checked, setChecked] = useState(true);
+
+<Checkbox.Root checked={checked} onCheckedChange={setChecked}>
+  <Checkbox.Input />
+  <Checkbox.Label>Subscribe to updates ({checked ? 'on' : 'off'})</Checkbox.Label>
+</Checkbox.Root>`}
+>
+  <ControlledCheckbox />
+</Preview>
+
+### Sizes
+
+`medium` (default) fits most forms; `small` for dense rows, `large` for touch targets. The box, font,
+and spacing all scale together.
+
+<Preview
+  code={`<Checkbox.Root size="small" defaultChecked>
+  <Checkbox.Input />
+  <Checkbox.Label>Small</Checkbox.Label>
+</Checkbox.Root>
+<Checkbox.Root size="medium" defaultChecked>
+  <Checkbox.Input />
+  <Checkbox.Label>Medium</Checkbox.Label>
+</Checkbox.Root>
+<Checkbox.Root size="large" defaultChecked>
+  <Checkbox.Input />
+  <Checkbox.Label>Large</Checkbox.Label>
+</Checkbox.Root>`}
+>
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+    <Checkbox.Root size="small" defaultChecked>
+      <Checkbox.Input />
+      <Checkbox.Label>Small</Checkbox.Label>
+    </Checkbox.Root>
+    <Checkbox.Root size="medium" defaultChecked>
+      <Checkbox.Input />
+      <Checkbox.Label>Medium</Checkbox.Label>
+    </Checkbox.Root>
+    <Checkbox.Root size="large" defaultChecked>
+      <Checkbox.Input />
+      <Checkbox.Label>Large</Checkbox.Label>
+    </Checkbox.Root>
+  </div>
+</Preview>
+
+### Indeterminate
+
+`indeterminate` renders the mixed mark and sets `aria-checked="mixed"` — use it for a "select all"
+box whose children are only partly selected.
+
+<Preview
+  code={`<Checkbox.Root indeterminate>
+  <Checkbox.Input />
+  <Checkbox.Label>Select all</Checkbox.Label>
+</Checkbox.Root>`}
+>
+  <Checkbox.Root indeterminate>
+    <Checkbox.Input />
+    <Checkbox.Label>Select all</Checkbox.Label>
+  </Checkbox.Root>
+</Preview>
+
+### Disabled
+
+`disabled` forwards the native attribute to the `Input` and dims the `Label`. It applies whether the
+box is checked or not.
+
+<Preview
+  code={`<Checkbox.Root disabled>
+  <Checkbox.Input />
+  <Checkbox.Label>Off and disabled</Checkbox.Label>
+</Checkbox.Root>
+<Checkbox.Root disabled defaultChecked>
+  <Checkbox.Input />
+  <Checkbox.Label>On and disabled</Checkbox.Label>
+</Checkbox.Root>`}
+>
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+    <Checkbox.Root disabled>
+      <Checkbox.Input />
+      <Checkbox.Label>Off and disabled</Checkbox.Label>
+    </Checkbox.Root>
+    <Checkbox.Root disabled defaultChecked>
+      <Checkbox.Input />
+      <Checkbox.Label>On and disabled</Checkbox.Label>
+    </Checkbox.Root>
+  </div>
+</Preview>
+
+## Anatomy
+
+```tsx
+import { Checkbox } from '@sipe-team/checkbox';
+
+export default () => (
+  <Checkbox.Root defaultChecked>
+    <Checkbox.Input />
+    <Checkbox.Label>Label</Checkbox.Label>
+  </Checkbox.Root>
+);
+```
+
+`Root` renders a `<div>` and provides context; `Input` and `Label` read from it and throw when
+rendered outside a `Root`. State (`checked`, `size`, `disabled`, `indeterminate`) lives on `Root`,
+not on the individual parts.
+
+## API Reference
+
+### `Checkbox.Root`
+
+Renders a `<div>` wrapper and forwards its `ref` to the underlying `<input>`.
+
+| Prop              | Type                                | Default    | Description                                                    |
+| ----------------- | ----------------------------------- | ---------- | -------------------------------------------------------------- |
+| `children`        | `ReactNode`                         | —          | Required. Usually a `Checkbox.Input` and a `Checkbox.Label`.   |
+| `size`            | `'small' \| 'medium' \| 'large'`    | `'medium'` | Scales the box, font size, and spacing.                        |
+| `checked`         | `boolean`                           | —          | Controlled checked state. Pair with `onCheckedChange`.         |
+| `defaultChecked`  | `boolean`                           | `false`    | Initial checked state when uncontrolled.                       |
+| `onCheckedChange` | `(checked: boolean) => void`        | —          | Called with the next checked value on toggle.                  |
+| `indeterminate`   | `boolean`                           | `false`    | Renders the mixed mark and sets `aria-checked="mixed"`.        |
+| `disabled`        | `boolean`                           | —          | Disables the input and dims the label.                         |
+| `className`       | `string`                            | —          | Appended to the container class.                               |
+| `style`           | `CSSProperties`                     | —          | Applied to the container `<div>`.                              |
+
+Also accepts most of `ComponentProps<'input'>` (`id`, `name`, `value`, `required`, `onChange`, …);
+they flow through context onto the rendered `<input>`. When no `id` is given, `Root` generates one.
+
+### `Checkbox.Input`
+
+Renders `<input type="checkbox">` and forwards its `ref`. Reads `checked`, `disabled`, `size`, and
+`indeterminate` from `Root`, so those are **not** set here.
+
+| Prop        | Type                             | Default | Description                                              |
+| ----------- | -------------------------------- | ------- | -------------------------------------------------------- |
+| `onChange`  | `ChangeEventHandler<'input'>`    | —       | Called alongside `Root`'s handlers when the box toggles. |
+| `name`      | `string`                         | —       | Overrides the `name` inherited from `Root`.              |
+| `value`     | `string`                         | `'on'`  | Form value submitted when checked.                       |
+| `className` | `string`                         | —       | Appended to the input class.                             |
+
+Accepts the rest of `ComponentProps<'input'>` except `size`, `checked`, and `id`, which come from
+`Root`.
+
+### `Checkbox.Label`
+
+Renders a `<label>` and forwards its `ref`. Its `htmlFor` is set to the `id` from `Root`, so clicking
+it toggles the input.
+
+| Prop        | Type        | Default | Description                        |
+| ----------- | ----------- | ------- | ---------------------------------- |
+| `children`  | `ReactNode` | —       | Required. Label text.              |
+| `className` | `string`    | —       | Appended to the label class.       |
+
+Also accepts `ComponentProps<'label'>`.
+
+## Accessibility
+
+- `Root` generates a stable `id` (via `useId`) and shares it, so `Label`'s `htmlFor` matches
+  `Input`'s `id`. The label is announced by screen readers and toggles the box on click.
+- `indeterminate` sets `aria-checked="mixed"` on the input.
+- `disabled` sets the native `disabled` attribute on the input.
+
+## Known limitations
+
+`indeterminate` only sets `aria-checked="mixed"` and the mixed visual — it does **not** set the
+native `HTMLInputElement.indeterminate` DOM property, so `:indeterminate` CSS and native form
+semantics do not apply.

--- a/www/package.json
+++ b/www/package.json
@@ -22,6 +22,7 @@
     "@mdx-js/react": "^3.0.0",
     "@sipe-team/accordion": "workspace:*",
     "@sipe-team/button": "workspace:*",
+    "@sipe-team/checkbox": "workspace:*",
     "@sipe-team/icon": "workspace:*",
     "@sipe-team/tokens": "workspace:*",
     "clsx": "^2.0.0",


### PR DESCRIPTION
## Changes

Checkbox를 문서로 추가하면서, 문서 프로덕션 빌드를 막던 패키징 버그와 React 경고를 같은 PR에서 고칩니다.

**`packages/checkbox` 버그 수정** (`@sipe-team/checkbox`: patch)
- **SVG 애셋**: `Checkbox.css.ts`가 `url("public/check.svg")` / `url("public/indeterminate.svg")`를 참조했는데, esbuild(tsup)는 해석했지만 소스 컴파일 소비자(webpack + vanilla-extract 플러그인, 예: 문서 사이트)는 해석하지 못해 프로덕션 빌드가 깨졌습니다. 체크 마크는 `<input>` 자체의 `background-image`로 얹히는(자식을 넣을 수 없는 void 요소) 구조라, 마크를 data-URI로 인라인해 두 번들러 모두 외부 애셋 해석 없이 동일하게 렌더하도록 했습니다. (`src/public/*.svg` 삭제) — SVG 마크업은 읽고 수정할 수 있게 그대로 두고, 빌드타임에 `svgToDataUri()`(`encodeURIComponent`)로 인코딩합니다.
- **`checked` + `defaultChecked` 경고**: `Root`가 `defaultChecked`를 소비하지 않아 context를 통해 항상 설정되는 `checked`와 함께 `<input>`으로 새어나가 React의 checked+defaultChecked 경고를 냈습니다. 이제 `Root`가 `defaultChecked`를 구조분해로 소비(비제어 초기값에만 사용)해 input에는 `checked`만 전달됩니다.

**`checkbox.mdx`**
- Installation / Usage / Examples / Anatomy / API Reference. API 표는 소스를 직접 읽고 수동 작성.
- Root/Input/Label 3파트, controlled/uncontrolled, indeterminate, disabled 상태를 다룹니다. controlled 예제 코드를 라이브 데모와 일치시켰습니다.

## Visuals
<img width="1613" height="1140" alt="스크린샷 2026-07-21 오후 10 03 20" src="https://github.com/user-attachments/assets/764e13aa-ead3-4b4c-b8b4-8b87fefbd2be" />


## Checklist
- [x] Have you written the functional specifications? — 문서 자체가 명세
- [x] Have you written the test code? — 패키지 테스트 19개 통과. 문서는 프로덕션 빌드로 검증

## Additional Discussion Points
- 이 fix가 없으면 문서 사이트 프로덕션 빌드 자체가 실패하므로, 문서 PR과 묶는 게 자연스럽습니다. changeset 포함(patch).
