### PR TITLE
refactor(input): migrate to semantic design tokens and restructure layout to fix dead-click areas

### DIFF
--- a/.changeset/input-semantic-tokens.md
+++ b/.changeset/input-semantic-tokens.md
@@ -1,0 +1,5 @@
+---
+"@sipe-team/input": patch
+---
+
+Apply semantic design tokens to Input (border, spacing, radius, typography, foreground). Fix fontWeight to regular (prop removed pending design review).

--- a/.changeset/input-semantic-tokens.md
+++ b/.changeset/input-semantic-tokens.md
@@ -8,3 +8,4 @@ Apply semantic design tokens and field API updates to Input
 - Fix `fontWeight` to regular (prop removed pending design review)
 - Move field chrome (border/focus) onto the `input` element; use `span` wrapper
 - Add `validation` prop for border-only `error` / `success` states (FormField-ready)
+- Style native `readOnly` distinctly from `disabled` (muted background, default cursor)

--- a/.changeset/input-semantic-tokens.md
+++ b/.changeset/input-semantic-tokens.md
@@ -2,4 +2,9 @@
 "@sipe-team/input": patch
 ---
 
-Apply semantic design tokens to Input (border, spacing, radius, typography, foreground). Fix fontWeight to regular (prop removed pending design review).
+Apply semantic design tokens and field API updates to Input
+
+- Replace local color/spacing/typography with semantic `vars`
+- Fix `fontWeight` to regular (prop removed pending design review)
+- Move field chrome (border/focus) onto the `input` element; use `span` wrapper
+- Add `validation` prop for border-only `error` / `success` states (FormField-ready)

--- a/.changeset/input-semantic-tokens.md
+++ b/.changeset/input-semantic-tokens.md
@@ -1,5 +1,5 @@
 ---
-"@sipe-team/input": patch
+"@sipe-team/input": minor
 ---
 
 Apply semantic design tokens and field API updates to Input

--- a/packages/input/src/Input.css.ts
+++ b/packages/input/src/Input.css.ts
@@ -3,54 +3,63 @@ import { vars } from '@sipe-team/tokens';
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
-import type { InputFontSize } from './Input';
+import type { InputFontSize, InputValidation } from './Input';
 
 export const defaultFontSize: InputFontSize = 16;
+export const defaultValidation: InputValidation = 'default';
 
-export const inputWrapper = recipe({
+/** Positioning context only — no chrome, so clicks can't land in a dead gap. */
+export const inputWrapper = style({
+  position: 'relative',
+  display: 'block',
+  flex: 1,
+  minWidth: 0,
+});
+
+export const inputField = recipe({
   base: {
-    position: 'relative',
+    boxSizing: 'border-box',
     display: 'block',
-    flex: 1,
+    width: '100%',
+    margin: 0,
     fontStyle: 'normal',
     textAlign: 'start',
     color: vars.color.foreground.default,
     fontFamily: vars.typography.fontFamily,
     fontWeight: vars.typography.fontWeight.regular,
+    backgroundColor: 'transparent',
     borderRadius: vars.radius.component.md,
     borderWidth: '1px',
     borderStyle: 'solid',
     borderColor: vars.color.border.default,
-    backgroundColor: 'transparent',
+    paddingBlock: vars.spacing.component.sm,
+    paddingInline: vars.spacing.component.md,
+    outline: 'none',
 
-    '@supports': {
-      'selector(:has(*))': {
-        selectors: {
-          '&:where(:hover:not(:has(input:disabled, input:focus)))': {
-            borderColor: vars.color.border.strong,
-          },
-          '&:where(:has(input:focus))': {
-            borderColor: vars.color.border.focus,
-            outline: `2px solid ${vars.color.border.focus}`,
-            outlineOffset: '-1px',
-          },
-          '&:where(:has(input:disabled))': {
-            backgroundColor: vars.color.background.muted,
-            borderColor: vars.color.border.default,
-          },
-        },
+    selectors: {
+      '&::-webkit-search-cancel-button': {
+        appearance: 'none',
       },
-      'not selector(:has(*))': {
-        selectors: {
-          '&:where(:hover:not(:focus-within))': {
-            borderColor: vars.color.border.strong,
-          },
-          '&:where(:focus-within)': {
-            borderColor: vars.color.border.focus,
-            outline: `2px solid ${vars.color.border.focus}`,
-            outlineOffset: '-1px',
-          },
-        },
+      '&::placeholder': {
+        color: vars.color.foreground.muted,
+      },
+      '&:hover:not(:disabled):not(:focus)': {
+        borderColor: vars.color.border.strong,
+      },
+      '&:focus': {
+        borderColor: vars.color.border.focus,
+        outline: `2px solid ${vars.color.border.focus}`,
+        outlineOffset: '-1px',
+      },
+      '&:disabled': {
+        backgroundColor: vars.color.background.muted,
+        borderColor: vars.color.border.default,
+        color: vars.color.foreground.subtle,
+        cursor: 'not-allowed',
+      },
+      '&:where(:autofill, [data-com-onepassword-filled])': {
+        backgroundClip: 'text',
+        WebkitTextFillColor: vars.color.foreground.default,
       },
     },
   },
@@ -67,56 +76,40 @@ export const inputWrapper = recipe({
       36: { fontSize: vars.typography.fontSize['800'] },
       48: { fontSize: vars.typography.fontSize['900'] },
     },
-  },
-  defaultVariants: {
-    fontSize: defaultFontSize,
-  },
-});
-
-export const inputElement = style({
-  boxSizing: 'border-box',
-  display: 'block',
-  width: '100%',
-  textAlign: 'inherit',
-  color: vars.color.foreground.default,
-  fontFamily: 'inherit',
-  outline: 'none',
-  border: 'none',
-  backgroundColor: 'transparent',
-  fontSize: 'inherit',
-  fontWeight: 'inherit',
-  margin: 0,
-  paddingBlock: vars.spacing.component.sm,
-  paddingInline: vars.spacing.component.md,
-
-  selectors: {
-    '&::-webkit-search-cancel-button': {
-      appearance: 'none',
-    },
-    '&::placeholder': {
-      color: vars.color.foreground.muted,
-    },
-  },
-
-  '@supports': {
-    'selector(:has(*))': {
-      selectors: {
-        '&:where(:autofill, [data-com-onepassword-filled])': {
-          backgroundClip: 'text',
-          WebkitTextFillColor: vars.color.foreground.default,
+    validation: {
+      default: {},
+      error: {
+        borderColor: vars.color.status.danger.border,
+        selectors: {
+          '&:hover:not(:disabled):not(:focus)': {
+            borderColor: vars.color.status.danger.border,
+          },
+          '&:disabled': {
+            borderColor: vars.color.border.default,
+          },
         },
-        '&:where(:disabled)': {
-          backgroundColor: 'transparent',
-          color: vars.color.foreground.subtle,
-          cursor: 'not-allowed',
+      },
+      success: {
+        borderColor: vars.color.status.success.border,
+        selectors: {
+          '&:hover:not(:disabled):not(:focus)': {
+            borderColor: vars.color.status.success.border,
+          },
+          '&:disabled': {
+            borderColor: vars.color.border.default,
+          },
         },
       },
     },
   },
+  defaultVariants: {
+    fontSize: defaultFontSize,
+    validation: defaultValidation,
+  },
 });
 
 /** Reserve trailing space so text/caret never sit under the absolute action. */
-export const inputElementWithAction = style({
+export const inputFieldWithAction = style({
   paddingInlineEnd: `calc(${vars.spacing.component.xl} + ${vars.spacing.component.md} + ${vars.spacing.component.xs})`,
 });
 
@@ -127,6 +120,7 @@ export const inputAction = style({
   top: '50%',
   right: vars.spacing.component.md,
   transform: 'translateY(-50%)',
+  zIndex: 1,
   width: vars.spacing.component.xl,
   height: vars.spacing.component.xl,
   display: 'flex',

--- a/packages/input/src/Input.css.ts
+++ b/packages/input/src/Input.css.ts
@@ -43,13 +43,19 @@ export const inputField = recipe({
       '&::placeholder': {
         color: vars.color.foreground.muted,
       },
-      '&:hover:not(:disabled):not(:focus)': {
+      '&:hover:not(:disabled):not(:focus):not(:read-only)': {
         borderColor: vars.color.border.strong,
       },
       '&:focus': {
         borderColor: vars.color.border.focus,
         outline: `2px solid ${vars.color.border.focus}`,
         outlineOffset: '-1px',
+      },
+      '&:read-only:not(:disabled)': {
+        backgroundColor: vars.color.background.muted,
+        borderColor: vars.color.border.default,
+        color: vars.color.foreground.default,
+        cursor: 'default',
       },
       '&:disabled': {
         backgroundColor: vars.color.background.muted,
@@ -81,7 +87,7 @@ export const inputField = recipe({
       error: {
         borderColor: vars.color.status.danger.border,
         selectors: {
-          '&:hover:not(:disabled):not(:focus)': {
+          '&:hover:not(:disabled):not(:focus):not(:read-only)': {
             borderColor: vars.color.status.danger.border,
           },
           '&:disabled': {
@@ -92,7 +98,7 @@ export const inputField = recipe({
       success: {
         borderColor: vars.color.status.success.border,
         selectors: {
-          '&:hover:not(:disabled):not(:focus)': {
+          '&:hover:not(:disabled):not(:focus):not(:read-only)': {
             borderColor: vars.color.status.success.border,
           },
           '&:disabled': {

--- a/packages/input/src/Input.css.ts
+++ b/packages/input/src/Input.css.ts
@@ -1,60 +1,53 @@
-import { color } from '@sipe-team/tokens';
+import { vars } from '@sipe-team/tokens';
 
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
-import type { InputFontSize, InputFontWeight } from './Input';
-
-// TODO ThemeProvider 적용
-export const colors = {
-  inputRing: color.gray800,
-  defaultInputOutline: color.gray400,
-  disabledBackground: color.gray300,
-} as const;
-
-export const spacing = {
-  defaultInputPadding: '8px',
-  defaultBorderRadius: '8px',
-  defaultActionSize: '24px',
-} as const;
-
-export const weight = {
-  regular: 400,
-  medium: 500,
-  semiBold: 600,
-  bold: 700,
-} as const;
+import type { InputFontSize } from './Input';
 
 export const defaultFontSize: InputFontSize = 16;
-export const defaultFontWeight: InputFontWeight = 'regular';
 
 export const inputWrapper = recipe({
   base: {
-    display: 'flex',
+    position: 'relative',
+    display: 'block',
     flex: 1,
-    alignItems: 'center',
     fontStyle: 'normal',
     textAlign: 'start',
-    padding: spacing.defaultInputPadding,
-    borderRadius: spacing.defaultBorderRadius,
-    outline: `1px solid ${colors.defaultInputOutline}`,
+    color: vars.color.foreground.default,
+    fontFamily: vars.typography.fontFamily,
+    fontWeight: vars.typography.fontWeight.regular,
+    borderRadius: vars.radius.component.md,
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: vars.color.border.default,
+    backgroundColor: 'transparent',
 
     '@supports': {
       'selector(:has(*))': {
         selectors: {
+          '&:where(:hover:not(:has(input:disabled, input:focus)))': {
+            borderColor: vars.color.border.strong,
+          },
           '&:where(:has(input:focus))': {
-            outline: `2px solid ${colors.defaultInputOutline}`,
+            borderColor: vars.color.border.focus,
+            outline: `2px solid ${vars.color.border.focus}`,
             outlineOffset: '-1px',
           },
           '&:where(:has(input:disabled))': {
-            backgroundColor: colors.disabledBackground,
+            backgroundColor: vars.color.background.muted,
+            borderColor: vars.color.border.default,
           },
         },
       },
       'not selector(:has(*))': {
         selectors: {
+          '&:where(:hover:not(:focus-within))': {
+            borderColor: vars.color.border.strong,
+          },
           '&:where(:focus-within)': {
-            outline: `2px solid ${colors.defaultInputOutline}`,
+            borderColor: vars.color.border.focus,
+            outline: `2px solid ${vars.color.border.focus}`,
             outlineOffset: '-1px',
           },
         },
@@ -63,43 +56,45 @@ export const inputWrapper = recipe({
   },
   variants: {
     fontSize: {
-      12: { fontSize: '12px' },
-      14: { fontSize: '14px' },
-      16: { fontSize: '16px' },
-      18: { fontSize: '18px' },
-      20: { fontSize: '20px' },
-      24: { fontSize: '24px' },
-      28: { fontSize: '28px' },
-      32: { fontSize: '32px' },
-      36: { fontSize: '36px' },
-      48: { fontSize: '48px' },
-    },
-    fontWeight: {
-      regular: { fontWeight: weight.regular },
-      medium: { fontWeight: weight.medium },
-      semiBold: { fontWeight: weight.semiBold },
-      bold: { fontWeight: weight.bold },
+      12: { fontSize: vars.typography.fontSize['050'] },
+      14: { fontSize: vars.typography.fontSize['100'] },
+      16: { fontSize: vars.typography.fontSize['200'] },
+      18: { fontSize: vars.typography.fontSize['300'] },
+      20: { fontSize: vars.typography.fontSize['400'] },
+      24: { fontSize: vars.typography.fontSize['500'] },
+      28: { fontSize: vars.typography.fontSize['600'] },
+      32: { fontSize: vars.typography.fontSize['700'] },
+      36: { fontSize: vars.typography.fontSize['800'] },
+      48: { fontSize: vars.typography.fontSize['900'] },
     },
   },
   defaultVariants: {
     fontSize: defaultFontSize,
-    fontWeight: defaultFontWeight,
   },
 });
 
 export const inputElement = style({
+  boxSizing: 'border-box',
+  display: 'block',
   width: '100%',
-  display: 'flex',
-  alignItems: 'center',
   textAlign: 'inherit',
-  outline: '1px solid transparent',
+  color: vars.color.foreground.default,
+  fontFamily: 'inherit',
+  outline: 'none',
   border: 'none',
+  backgroundColor: 'transparent',
   fontSize: 'inherit',
   fontWeight: 'inherit',
+  margin: 0,
+  paddingBlock: vars.spacing.component.sm,
+  paddingInline: vars.spacing.component.md,
 
   selectors: {
     '&::-webkit-search-cancel-button': {
       appearance: 'none',
+    },
+    '&::placeholder': {
+      color: vars.color.foreground.muted,
     },
   },
 
@@ -108,33 +103,52 @@ export const inputElement = style({
       selectors: {
         '&:where(:autofill, [data-com-onepassword-filled])': {
           backgroundClip: 'text',
-          WebkitTextFillColor: color.gray900,
+          WebkitTextFillColor: vars.color.foreground.default,
         },
         '&:where(:disabled)': {
           backgroundColor: 'transparent',
+          color: vars.color.foreground.subtle,
+          cursor: 'not-allowed',
         },
       },
     },
   },
 });
 
+/** Reserve trailing space so text/caret never sit under the absolute action. */
+export const inputElementWithAction = style({
+  paddingInlineEnd: `calc(${vars.spacing.component.xl} + ${vars.spacing.component.md} + ${vars.spacing.component.xs})`,
+});
+
 export const inputAction = style({
   all: 'unset',
-  width: spacing.defaultActionSize,
-  height: spacing.defaultActionSize,
+  boxSizing: 'border-box',
+  position: 'absolute',
+  top: '50%',
+  right: vars.spacing.component.md,
+  transform: 'translateY(-50%)',
+  width: vars.spacing.component.xl,
+  height: vars.spacing.component.xl,
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
-  borderRadius: spacing.defaultBorderRadius,
+  color: vars.color.foreground.subtle,
+  borderRadius: vars.radius.component.md,
+  cursor: 'pointer',
+  transition: 'color 0.15s ease, background-color 0.15s ease',
 
-  '@supports': {
-    'selector(:has(*))': {
-      selectors: {
-        '&:focus': {
-          outline: `2px solid ${colors.defaultInputOutline}`,
-          outlineOffset: '3px',
-        },
-      },
+  selectors: {
+    '&:hover': {
+      color: vars.color.foreground.default,
+      backgroundColor: vars.color.background.muted,
+    },
+    '&:active': {
+      color: vars.color.foreground.default,
+      backgroundColor: vars.color.background.subtle,
+    },
+    '&:focus-visible': {
+      outline: `2px solid ${vars.color.border.focus}`,
+      outlineOffset: '3px',
     },
   },
 });

--- a/packages/input/src/Input.css.ts
+++ b/packages/input/src/Input.css.ts
@@ -8,12 +8,13 @@ import type { InputFontSize, InputValidation } from './Input';
 export const defaultFontSize: InputFontSize = 16;
 export const defaultValidation: InputValidation = 'default';
 
-/** Positioning context only — no chrome, so clicks can't land in a dead gap. */
 export const inputWrapper = style({
   position: 'relative',
   display: 'block',
   flex: 1,
   minWidth: 0,
+  cursor: 'default',
+  userSelect: 'none',
 });
 
 export const inputField = recipe({
@@ -35,6 +36,7 @@ export const inputField = recipe({
     paddingBlock: vars.spacing.component.sm,
     paddingInline: vars.spacing.component.md,
     outline: 'none',
+    cursor: 'text',
 
     selectors: {
       '&::-webkit-search-cancel-button': {

--- a/packages/input/src/Input.css.ts
+++ b/packages/input/src/Input.css.ts
@@ -46,11 +46,6 @@ export const inputField = recipe({
       '&:hover:not(:disabled):not(:focus):not(:read-only)': {
         borderColor: vars.color.border.strong,
       },
-      '&:focus': {
-        borderColor: vars.color.border.focus,
-        outline: `2px solid ${vars.color.border.focus}`,
-        outlineOffset: '-1px',
-      },
       '&:read-only:not(:disabled)': {
         backgroundColor: vars.color.background.muted,
         borderColor: vars.color.border.default,
@@ -83,7 +78,17 @@ export const inputField = recipe({
       48: { fontSize: vars.typography.fontSize['900'] },
     },
     validation: {
-      default: {},
+      default: {
+        selectors: {
+          '&:focus': {
+            borderColor: vars.color.border.focus,
+            outlineWidth: '2px',
+            outlineStyle: 'solid',
+            outlineColor: vars.color.border.focus,
+            outlineOffset: '-1px',
+          },
+        },
+      },
       error: {
         borderColor: vars.color.status.danger.border,
         selectors: {

--- a/packages/input/src/Input.stories.tsx
+++ b/packages/input/src/Input.stories.tsx
@@ -76,6 +76,13 @@ export const disabled: Story = {
   },
 };
 
+export const ReadOnly: Story = {
+  args: {
+    readOnly: true,
+    defaultValue: 'read only value',
+  },
+};
+
 export const ValidationError: Story = {
   args: {
     validation: 'error',

--- a/packages/input/src/Input.stories.tsx
+++ b/packages/input/src/Input.stories.tsx
@@ -43,6 +43,10 @@ const meta = {
       options: ['email', 'password', 'search', 'tel', 'text', 'url'],
       control: { type: 'radio' },
     },
+    validation: {
+      options: ['default', 'error', 'success'],
+      control: { type: 'radio' },
+    },
   },
 } satisfies Meta<typeof Input>;
 export default meta;
@@ -69,6 +73,20 @@ export const disabled: Story = {
   args: {
     disabled: true,
     value: 'test',
+  },
+};
+
+export const ValidationError: Story = {
+  args: {
+    validation: 'error',
+    defaultValue: 'invalid value',
+  },
+};
+
+export const ValidationSuccess: Story = {
+  args: {
+    validation: 'success',
+    defaultValue: 'valid value',
   },
 };
 

--- a/packages/input/src/Input.stories.tsx
+++ b/packages/input/src/Input.stories.tsx
@@ -1,8 +1,23 @@
-import { useRef, useState } from 'react';
+import { type ReactNode, useRef, useState } from 'react';
 
-import type { StoryObj } from '@storybook/react';
+import { vars } from '@sipe-team/tokens';
+
+import type { Meta, StoryObj } from '@storybook/react';
 
 import { Action, Input } from './Input';
+
+const DarkSurface = ({ children }: { children: ReactNode }) => (
+  <div
+    style={{
+      backgroundColor: vars.color.background.base,
+      padding: 24,
+      minWidth: 320,
+      borderRadius: vars.radius.component.lg,
+    }}
+  >
+    {children}
+  </div>
+);
 
 const meta = {
   title: 'Components/Input',
@@ -10,10 +25,16 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
+  decorators: [
+    (Story) => (
+      <DarkSurface>
+        <Story />
+      </DarkSurface>
+    ),
+  ],
   args: {
     disabled: false,
     fontSize: 16,
-    fontWeight: 'regular',
     placeholder: 'placeholder',
     type: 'text',
   },
@@ -23,7 +44,7 @@ const meta = {
       control: { type: 'radio' },
     },
   },
-};
+} satisfies Meta<typeof Input>;
 export default meta;
 
 type Story = StoryObj<typeof meta>;
@@ -31,7 +52,6 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     type: 'password',
-    fontWeight: 'regular',
     fontSize: 20,
   },
 

--- a/packages/input/src/Input.stories.tsx
+++ b/packages/input/src/Input.stories.tsx
@@ -9,7 +9,7 @@ import { Action, Input } from './Input';
 const DarkSurface = ({ children }: { children: ReactNode }) => (
   <div
     style={{
-      backgroundColor: vars.color.background.base,
+      backgroundColor: vars.color.background.subtle,
       padding: 24,
       minWidth: 320,
       borderRadius: vars.radius.component.lg,

--- a/packages/input/src/Input.test.tsx
+++ b/packages/input/src/Input.test.tsx
@@ -7,7 +7,30 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, test } from 'vitest';
 
 import { Action, Input } from './Input';
-import { defaultFontSize, defaultFontWeight, weight } from './Input.css';
+import { defaultFontSize } from './Input.css';
+
+function ruleForClass(className: string): string {
+  const target = `.${className}`;
+  for (const sheet of Array.from(document.styleSheets)) {
+    let rules: CSSRuleList;
+    try {
+      rules = sheet.cssRules;
+    } catch {
+      continue;
+    }
+    for (const rule of Array.from(rules)) {
+      if (!('selectorText' in rule)) continue;
+      const selectorText = (rule as CSSStyleRule).selectorText ?? '';
+      const matches = selectorText.split(',').some((s) => s.trim() === target);
+      if (matches) return rule.cssText;
+    }
+  }
+  return '';
+}
+
+function rulesForElement(el: HTMLElement): string {
+  return el.className.split(/\s+/).filter(Boolean).map(ruleForClass).join('\n');
+}
 
 describe('Input 컴포넌트', () => {
   describe('렌더링', () => {
@@ -43,24 +66,33 @@ describe('Input 컴포넌트', () => {
       expect(screen.getByRole('textbox')).toHaveAttribute('spellCheck', 'false');
     });
 
-    test(`fontWeight가 미지정시 ${defaultFontWeight}, fontSize가 미지정시 ${defaultFontSize}px이 기본값으로 적용된다`, () => {
+    test(`fontSize 미지정시 ${defaultFontSize}, fontWeight는 regular semantic 토큰을 참조한다`, () => {
       const { container } = render(<Input />);
-      const element = container.firstChild as HTMLElement;
-      const computedStyle = getComputedStyle(element);
+      const applied = rulesForElement(container.firstChild as HTMLElement);
 
-      expect(computedStyle.fontSize).toBe(`${defaultFontSize}px`);
-      expect(computedStyle.fontWeight).toBe(`${weight[defaultFontWeight]}`);
+      expect(applied).toContain('var(--side-font-size-200)');
+      expect(applied).toContain('var(--side-font-weight-regular)');
     });
 
-    test('변경 폰트 사이즈, 폰트 웨이트 적용된다.', () => {
-      const fontSize = 24;
-      const fontWeight = 'semiBold';
-      const { container } = render(<Input fontSize={fontSize} fontWeight={fontWeight} />);
-      const element = container.firstChild as HTMLElement;
-      const computedStyle = getComputedStyle(element);
+    test('변경 폰트 사이즈 semantic 토큰을 참조한다', () => {
+      const { container } = render(<Input fontSize={24} />);
+      const applied = rulesForElement(container.firstChild as HTMLElement);
 
-      expect(computedStyle.fontSize).toBe(`${fontSize}px`);
-      expect(computedStyle.fontWeight).toBe(`${weight[fontWeight]}`);
+      expect(applied).toContain('var(--side-font-size-500)');
+      expect(applied).toContain('var(--side-font-weight-regular)');
+    });
+
+    test('인풋 기본 테두리·패딩·반경 semantic 토큰을 참조한다', () => {
+      const { container } = render(<Input />);
+      const wrapper = container.firstChild as HTMLElement;
+      const field = screen.getByRole('textbox');
+      const wrapperRules = rulesForElement(wrapper);
+      const fieldRules = rulesForElement(field);
+
+      expect(wrapperRules).toContain('var(--side-color-border-default)');
+      expect(wrapperRules).toContain('var(--side-radius-component-md)');
+      expect(fieldRules).toContain('var(--side-spacing-component-sm)');
+      expect(fieldRules).toContain('var(--side-spacing-component-md)');
     });
   });
 

--- a/packages/input/src/Input.test.tsx
+++ b/packages/input/src/Input.test.tsx
@@ -11,6 +11,7 @@ import { defaultFontSize } from './Input.css';
 
 function ruleForClass(className: string): string {
   const target = `.${className}`;
+  const matched: string[] = [];
   for (const sheet of Array.from(document.styleSheets)) {
     let rules: CSSRuleList;
     try {
@@ -21,11 +22,14 @@ function ruleForClass(className: string): string {
     for (const rule of Array.from(rules)) {
       if (!('selectorText' in rule)) continue;
       const selectorText = (rule as CSSStyleRule).selectorText ?? '';
-      const matches = selectorText.split(',').some((s) => s.trim() === target);
-      if (matches) return rule.cssText;
+      const matches = selectorText.split(',').some((s) => {
+        const part = s.trim();
+        return part === target || part.startsWith(`${target}:`) || part.startsWith(`${target}.`);
+      });
+      if (matches) matched.push(rule.cssText);
     }
   }
-  return '';
+  return matched.join('\n');
 }
 
 function rulesForElement(el: HTMLElement): string {
@@ -54,6 +58,16 @@ describe('Input 컴포넌트', () => {
       render(<Input disabled={true} />);
       const input = screen.getByRole('textbox');
       expect(input).toBeDisabled();
+    });
+
+    test('readOnly 상태가 올바르게 설정된다', () => {
+      render(<Input readOnly defaultValue="locked" />);
+      expect(screen.getByRole('textbox')).toHaveAttribute('readonly');
+    });
+
+    test('readOnly일 때 muted 배경 semantic 토큰을 참조한다', () => {
+      render(<Input readOnly defaultValue="locked" />);
+      expect(rulesForElement(screen.getByRole('textbox'))).toContain('var(--side-color-background-muted)');
     });
 
     test('classNames가 올바르게 적용된다', () => {

--- a/packages/input/src/Input.test.tsx
+++ b/packages/input/src/Input.test.tsx
@@ -67,35 +67,36 @@ describe('Input 컴포넌트', () => {
     });
 
     test(`fontSize 미지정시 ${defaultFontSize}, fontWeight는 regular semantic 토큰을 참조한다`, () => {
-      const { container } = render(<Input />);
-      const applied = rulesForElement(container.firstChild as HTMLElement);
+      render(<Input />);
+      const applied = rulesForElement(screen.getByRole('textbox'));
 
       expect(applied).toContain('var(--side-font-size-200)');
       expect(applied).toContain('var(--side-font-weight-regular)');
     });
 
     test('변경 폰트 사이즈 semantic 토큰을 참조한다', () => {
-      const { container } = render(<Input fontSize={24} />);
-      const applied = rulesForElement(container.firstChild as HTMLElement);
+      render(<Input fontSize={24} />);
+      const applied = rulesForElement(screen.getByRole('textbox'));
 
       expect(applied).toContain('var(--side-font-size-500)');
       expect(applied).toContain('var(--side-font-weight-regular)');
     });
 
     test('인풋 기본 테두리·패딩·반경 semantic 토큰을 참조한다', () => {
-      const { container } = render(<Input />);
-      const wrapper = container.firstChild as HTMLElement;
-      const field = screen.getByRole('textbox');
-      const wrapperRules = rulesForElement(wrapper);
-      const fieldRules = rulesForElement(field);
+      render(<Input />);
+      const fieldRules = rulesForElement(screen.getByRole('textbox'));
 
-      expect(wrapperRules).toContain('var(--side-color-border-default)');
-      expect(wrapperRules).toContain('var(--side-radius-component-md)');
+      expect(fieldRules).toContain('var(--side-color-border-default)');
+      expect(fieldRules).toContain('var(--side-radius-component-md)');
       expect(fieldRules).toContain('var(--side-spacing-component-sm)');
       expect(fieldRules).toContain('var(--side-spacing-component-md)');
     });
-  });
 
+    test('래퍼는 span이다', () => {
+      const { container } = render(<Input />);
+      expect((container.firstChild as HTMLElement).tagName).toBe('SPAN');
+    });
+  });
   describe('상호작용', () => {
     test('사용자 입력', async () => {
       render(<Input name="test" />);
@@ -140,6 +141,23 @@ describe('Input 컴포넌트', () => {
     test('Input 컴포넌트가 textbox role을 가진다', () => {
       render(<Input name="email" />);
       expect(screen.getByRole('textbox')).toBeInTheDocument();
+    });
+
+    test('validation이 error이면 aria-invalid가 설정된다', () => {
+      render(<Input validation="error" />);
+      expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true');
+    });
+  });
+
+  describe('validation', () => {
+    test('error일 때 danger border semantic 토큰을 참조한다', () => {
+      render(<Input validation="error" />);
+      expect(rulesForElement(screen.getByRole('textbox'))).toContain('var(--side-color-status-danger-border)');
+    });
+
+    test('success일 때 success border semantic 토큰을 참조한다', () => {
+      render(<Input validation="success" />);
+      expect(rulesForElement(screen.getByRole('textbox'))).toContain('var(--side-color-status-success-border)');
     });
   });
 });

--- a/packages/input/src/Input.test.tsx
+++ b/packages/input/src/Input.test.tsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, test } from 'vitest';
 
 import { Action, Input } from './Input';
-import { defaultFontSize } from './Input.css';
+import { defaultFontSize, inputFieldWithAction } from './Input.css';
 
 function ruleForClass(className: string): string {
   const target = `.${className}`;
@@ -128,6 +128,20 @@ describe('Input 컴포넌트', () => {
         </Input>,
       );
       expect(screen.getByRole('button')).toBeInTheDocument();
+    });
+
+    test('Action이 있으면 trailing padding 클래스가 적용된다', () => {
+      render(
+        <Input>
+          <Action>버튼</Action>
+        </Input>,
+      );
+      expect(screen.getByRole('textbox')).toHaveClass(inputFieldWithAction);
+    });
+
+    test('falsy children이면 trailing padding 클래스가 적용되지 않는다', () => {
+      render(<Input>{false}</Input>);
+      expect(screen.getByRole('textbox')).not.toHaveClass(inputFieldWithAction);
     });
 
     test('Action 버튼에 커스텀 클래스가 적용된다', () => {

--- a/packages/input/src/Input.tsx
+++ b/packages/input/src/Input.tsx
@@ -1,45 +1,42 @@
-import { type ComponentPropsWithoutRef, type ElementRef, forwardRef } from 'react';
+import { Children, type ComponentPropsWithoutRef, type ElementRef, forwardRef } from 'react';
 
 import { Slot } from '@radix-ui/react-slot';
 
 import cx from 'clsx';
 
-import { defaultFontSize, defaultFontWeight, inputAction, inputElement, inputWrapper, type weight } from './Input.css';
+import { defaultFontSize, inputAction, inputElement, inputElementWithAction, inputWrapper } from './Input.css';
 
+// TODO(design): fontSize API naming (px vs sm/md/lg) — pending designer sync
 export type InputFontSize = 12 | 14 | 16 | 18 | 20 | 24 | 28 | 32 | 36 | 48;
-export type InputFontWeight = keyof typeof weight;
+
+// TODO(design): confirm with design whether to expose fontWeight as a prop; currently fixed to regular
 type AllowedInputTypes = 'email' | 'password' | 'search' | 'tel' | 'text' | 'url';
 type InputFieldElement = ElementRef<'input'>;
 
 interface InputProps extends Omit<ComponentPropsWithoutRef<'input'>, 'type'> {
   type?: AllowedInputTypes;
   fontSize?: InputFontSize;
-  fontWeight?: InputFontWeight;
 }
 
 const Input = forwardRef<InputFieldElement, InputProps>((props, forwardedRef) => {
-  const {
-    children,
-    type = 'text',
-    fontWeight = defaultFontWeight,
-    fontSize = defaultFontSize,
-    className,
-    name,
-    ...inputProps
-  } = props;
+  const { children, type = 'text', fontSize = defaultFontSize, className, name, ...inputProps } = props;
+  const hasAction = Children.count(children) > 0;
 
   return (
-    <div role="presentation" className={cx(inputWrapper({ fontSize, fontWeight }), className)}>
-      <input name={name} type={type} spellCheck="false" ref={forwardedRef} className={inputElement} {...inputProps} />
+    <span role="presentation" className={cx(inputWrapper({ fontSize }), className)}>
+      <input
+        name={name}
+        type={type}
+        spellCheck="false"
+        ref={forwardedRef}
+        className={cx(inputElement, hasAction && inputElementWithAction)}
+        {...inputProps}
+      />
       {children}
-    </div>
+    </span>
   );
 });
 Input.displayName = 'Input';
-
-// * ****************************************
-// *               Input Action
-// * ****************************************
 
 type InputFieldActionElement = ElementRef<'button'>;
 type InputFieldActionType = 'button' | 'reset';

--- a/packages/input/src/Input.tsx
+++ b/packages/input/src/Input.tsx
@@ -4,10 +4,17 @@ import { Slot } from '@radix-ui/react-slot';
 
 import cx from 'clsx';
 
-import { defaultFontSize, inputAction, inputElement, inputElementWithAction, inputWrapper } from './Input.css';
+import { defaultFontSize, inputAction, inputField, inputFieldWithAction, inputWrapper } from './Input.css';
 
 // TODO(design): fontSize API naming (px vs sm/md/lg) — pending designer sync
 export type InputFontSize = 12 | 14 | 16 | 18 | 20 | 24 | 28 | 32 | 36 | 48;
+
+export const InputValidation = {
+  default: 'default',
+  error: 'error',
+  success: 'success',
+} as const;
+export type InputValidation = (typeof InputValidation)[keyof typeof InputValidation];
 
 // TODO(design): confirm with design whether to expose fontWeight as a prop; currently fixed to regular
 type AllowedInputTypes = 'email' | 'password' | 'search' | 'tel' | 'text' | 'url';
@@ -16,21 +23,32 @@ type InputFieldElement = ElementRef<'input'>;
 interface InputProps extends Omit<ComponentPropsWithoutRef<'input'>, 'type'> {
   type?: AllowedInputTypes;
   fontSize?: InputFontSize;
+  /** Border-only validation state for FormField composition. Messages stay outside Input. */
+  validation?: InputValidation;
 }
 
 const Input = forwardRef<InputFieldElement, InputProps>((props, forwardedRef) => {
-  const { children, type = 'text', fontSize = defaultFontSize, className, name, ...inputProps } = props;
+  const {
+    children,
+    type = 'text',
+    fontSize = defaultFontSize,
+    validation = InputValidation.default,
+    className,
+    name,
+    ...inputProps
+  } = props;
   const hasAction = Children.count(children) > 0;
 
   return (
-    <span role="presentation" className={cx(inputWrapper({ fontSize }), className)}>
+    <span role="presentation" className={cx(inputWrapper, className)}>
       <input
         name={name}
         type={type}
         spellCheck="false"
         ref={forwardedRef}
-        className={cx(inputElement, hasAction && inputElementWithAction)}
+        className={cx(inputField({ fontSize, validation }), hasAction && inputFieldWithAction)}
         {...inputProps}
+        aria-invalid={validation === InputValidation.error || inputProps['aria-invalid']}
       />
       {children}
     </span>

--- a/packages/input/src/Input.tsx
+++ b/packages/input/src/Input.tsx
@@ -37,7 +37,7 @@ const Input = forwardRef<InputFieldElement, InputProps>((props, forwardedRef) =>
     name,
     ...inputProps
   } = props;
-  const hasAction = Children.count(children) > 0;
+  const hasAction = Children.toArray(children).length > 0;
 
   return (
     <span role="presentation" className={cx(inputWrapper, className)}>


### PR DESCRIPTION
## Background

Input은 아직 디자인 팀과 정식으로 논의되지 않았고, 현재 SIPE 홈페이지에서도 사용되지 않는 컴포넌트입니다. 이런 상황을 고려했을 때 미래 사용성을 예측해서 기능을 확장하기보다, **디자인 시스템 체계(토큰)에 맞춰 통일시키는 작업을 우선**하는 게 맞다고 판단했습니다. 이번 PR은 그 첫 단계로, 임의로 정의해서 쓰던 스타일 값들을 `@sipe-team/tokens`의 semantic vars로 교체하고, Mantine / Ant Design / Vapor UI 등 주요 라이브러리에서 공통적으로 제공하는 input 스펙을 기준으로 현재 구현의 어긋난 부분(레이아웃 구조, 유효성 상태 표현 등)을 맞추는 데 집중했습니다.

## Changes

- Input 스타일을 `@sipe-team/tokens`의 semantic `vars`로 교체 (border / background / foreground / spacing / radius / typography)
- `fontWeight` prop 제거, regular로 고정
- `validation` prop 추가 (`default` | `error` | `success`) — 보더 스타일만 변경하며, 에러/성공 메시지 표시는 FormField 영역의 책임으로 분리
- 네이티브 `readOnly` 스타일 추가 (muted 배경으로 disabled와 시각적으로 구분)
- changeset: `.changeset/input-semantic-tokens.md`

## 레이아웃 구조 변경

기존에는 `div` wrapper가 border/padding/focus 스타일을 담당하고 내부 `<input>`은 투명한 구조였는데, 이 경우 wrapper와 input 사이의 여백에 클릭이 떨어지면 포커스가 잡히지 않는 dead click 영역이 생깁니다. Action 버튼이 있는 케이스에서는 버튼과 input 사이 클릭 시 input이 활성화되지 않을 위험도 있고요.

[Ant Design](https://ant.design/components/input)을 제외한 **[Vapor UI](https://vapor-ui.goorm.io/docs/components/text-input), [Mantine](https://mantine.dev/core/text-input/)은 border/padding/focus 스타일을 input 자체에 두는 방식**을 채택하고 있어 이를 따랐습니다.

- **wrapper `div` → `span`**: wrapper는 positioning context 역할만 하고 클릭/포커스 대상이 아니므로, 의미상 presentation 용도인 `span`이 더 적절하다고 판단했습니다.
- **border, padding, focus 스타일을 wrapper → `<input>`으로 이동**: 화면에 보이는 필드 전체 = 실제 입력 영역이 일치하도록 만들어 dead click 문제를 해소했습니다.
- Action 버튼은 기존처럼 input 위에 absolute로 배치하되, input에 trailing padding을 줘서 텍스트/캐럿이 버튼에 가리지 않도록 처리했습니다.

## Validation / ReadOnly

- 유효성 상태(`default` / `error` / `success`)에 따른 테두리 스타일 정의
- `readOnly` 속성 부여 시 노출되는 스타일 정의

## Storybook 참고사항

현재 컴포넌트 토큰이 다크모드 기준으로 작업되어 있는데 Storybook 자체는 라이트모드로 렌더링되고 있어, 컴포넌트가 다크모드 배경에서 보이는 것처럼 처리해 정상 동작을 확인할 수 있도록 했습니다. (라이트모드 대응은 별도 이슈로 분리 필요)

## Visuals

<img width="848" height="703" alt="image" src="https://github.com/user-attachments/assets/4cacbeb2-0ad6-410e-b160-bbcbdc085173" />

<img width="841" height="681" alt="image" src="https://github.com/user-attachments/assets/cd1091ac-95c3-45eb-ba29-561e19b14c47" />

<img width="838" height="701" alt="image" src="https://github.com/user-attachments/assets/039c4fde-01bd-47a9-aaf1-4a52540b1c03" />

## Checklist

- [x] Have you written the functional specifications?
- [x] Have you written the test code?

## Additional Discussion Points

- `fontSize` API 네이밍(px vs sm/md/lg), `fontWeight` 재노출 여부는 디자인 싱크 후속으로 진행
- FormField(라벨·메시지 영역)는 별도 작업으로 분리
- `warning` validation은 이번 범위에서 제외
- Storybook 라이트모드 대응 여부 논의 필요