### PR TITLE
 docs(www): document Radio & fix unwired legend style

### DIFF
--- a/.changeset/fix-radio-legend-style.md
+++ b/.changeset/fix-radio-legend-style.md
@@ -1,0 +1,8 @@
+---
+"@sipe-team/radio": patch
+---
+
+Apply the `radioGroupLegend` style to the `RadioGroup` legend. The style was
+defined but never wired to the `<legend>` element, so the group label rendered
+with browser-default styling instead of the intended weight, size, spacing, and
+token color.

--- a/packages/radio/src/RadioGroup.tsx
+++ b/packages/radio/src/RadioGroup.tsx
@@ -3,7 +3,7 @@ import { createContext, type PropsWithChildren, useId } from 'react';
 import clsx from 'clsx';
 
 import type { RadioSize } from './constants/sizes';
-import { radioGroup } from './Radio.css';
+import { radioGroup, radioGroupLegend } from './Radio.css';
 
 type RadioGroupContext = Omit<RadioGroupProps, 'labelText' | 'children'>;
 
@@ -34,7 +34,7 @@ export function RadioGroup({
 
   return (
     <fieldset className={clsx(radioGroup, className)} disabled={disabled}>
-      {labelText && <legend>{labelText}</legend>}
+      {labelText && <legend className={radioGroupLegend}>{labelText}</legend>}
       <RadioGroupContext.Provider value={{ ...rest, disabled, size, name }}>{children}</RadioGroupContext.Provider>
     </fieldset>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1196,6 +1196,9 @@ importers:
       '@sipe-team/icon':
         specifier: workspace:*
         version: link:../packages/icon
+      '@sipe-team/radio':
+        specifier: workspace:*
+        version: link:../packages/radio
       '@sipe-team/tokens':
         specifier: workspace:*
         version: link:../packages/tokens

--- a/www/docs/components/radio.mdx
+++ b/www/docs/components/radio.mdx
@@ -1,0 +1,228 @@
+---
+sidebar_label: Radio
+---
+
+import { useState } from 'react';
+import { Radio, RadioGroup } from '@sipe-team/radio';
+
+export const ControlledRadio = () => {
+  const [value, setValue] = useState('apple');
+  return (
+    <RadioGroup labelText={`Picked: ${value}`} value={value} onChangeValue={setValue}>
+      <Radio value="apple">Apple</Radio>
+      <Radio value="orange">Orange</Radio>
+      <Radio value="grape">Grape</Radio>
+    </RadioGroup>
+  );
+};
+
+# Radio
+
+A grouped single-choice control — a `RadioGroup` that owns the selected value, wrapping one `Radio`
+per option.
+
+## Installation
+
+```sh
+npm install @sipe-team/radio
+```
+
+```ts
+import '@sipe-team/radio/styles.css';
+```
+
+## Usage
+
+`RadioGroup` renders a `<fieldset>` and shares a `name`, `size`, and the selected value through
+context, so every `Radio` inside it is wired into one group automatically — picking one clears the
+rest. Clicking a `Radio`'s label selects it.
+
+<Preview
+  code={`<RadioGroup labelText="Pick a fruit" defaultValue="orange">
+  <Radio value="apple">Apple</Radio>
+  <Radio value="orange">Orange</Radio>
+  <Radio value="grape">Grape</Radio>
+</RadioGroup>`}
+>
+  <RadioGroup labelText="Pick a fruit" defaultValue="orange">
+    <Radio value="apple">Apple</Radio>
+    <Radio value="orange">Orange</Radio>
+    <Radio value="grape">Grape</Radio>
+  </RadioGroup>
+</Preview>
+
+## Examples
+
+### Uncontrolled
+
+Give `RadioGroup` a `defaultValue` and let it track the selection itself — the common case for forms
+that read the value on submit. `RadioGroup` generates a `name` when you do not pass one, so the
+options are still submitted as a single field.
+
+<Preview
+  code={`<RadioGroup labelText="Shipping" defaultValue="standard">
+  <Radio value="standard">Standard</Radio>
+  <Radio value="express">Express</Radio>
+</RadioGroup>`}
+>
+  <RadioGroup labelText="Shipping" defaultValue="standard">
+    <Radio value="standard">Standard</Radio>
+    <Radio value="express">Express</Radio>
+  </RadioGroup>
+</Preview>
+
+### Controlled
+
+Own the state yourself with `value` and `onChangeValue` when another part of the UI has to react to
+the selection. `onChangeValue` receives the next value string.
+
+<Preview
+  code={`const [value, setValue] = useState('apple');
+
+<RadioGroup labelText={\`Picked: \${value}\`} value={value} onChangeValue={setValue}>
+  <Radio value="apple">Apple</Radio>
+  <Radio value="orange">Orange</Radio>
+  <Radio value="grape">Grape</Radio>
+</RadioGroup>`}
+>
+  <ControlledRadio />
+</Preview>
+
+### Sizes
+
+`medium` (default) fits most forms; `small` for dense rows, `large` for touch targets. Set `size` on
+`RadioGroup` to scale every option, and the dot, font, and spacing all scale together.
+
+<Preview
+  code={`<RadioGroup size="small" labelText="Small" defaultValue="a">
+  <Radio value="a">Option A</Radio>
+  <Radio value="b">Option B</Radio>
+</RadioGroup>
+<RadioGroup size="medium" labelText="Medium" defaultValue="a">
+  <Radio value="a">Option A</Radio>
+  <Radio value="b">Option B</Radio>
+</RadioGroup>
+<RadioGroup size="large" labelText="Large" defaultValue="a">
+  <Radio value="a">Option A</Radio>
+  <Radio value="b">Option B</Radio>
+</RadioGroup>`}
+>
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+    <RadioGroup size="small" labelText="Small" defaultValue="a">
+      <Radio value="a">Option A</Radio>
+      <Radio value="b">Option B</Radio>
+    </RadioGroup>
+    <RadioGroup size="medium" labelText="Medium" defaultValue="a">
+      <Radio value="a">Option A</Radio>
+      <Radio value="b">Option B</Radio>
+    </RadioGroup>
+    <RadioGroup size="large" labelText="Large" defaultValue="a">
+      <Radio value="a">Option A</Radio>
+      <Radio value="b">Option B</Radio>
+    </RadioGroup>
+  </div>
+</Preview>
+
+### Disabled
+
+`disabled` on `RadioGroup` disables every option via the native `<fieldset disabled>`; `disabled` on
+a single `Radio` disables just that one. Both dim the affected labels.
+
+<Preview
+  code={`<RadioGroup labelText="Whole group" disabled defaultValue="a">
+  <Radio value="a">Selected but disabled</Radio>
+  <Radio value="b">Also disabled</Radio>
+</RadioGroup>
+<RadioGroup labelText="Single option" defaultValue="a">
+  <Radio value="a">Enabled</Radio>
+  <Radio value="b" disabled>Disabled</Radio>
+</RadioGroup>`}
+>
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+    <RadioGroup labelText="Whole group" disabled defaultValue="a">
+      <Radio value="a">Selected but disabled</Radio>
+      <Radio value="b">Also disabled</Radio>
+    </RadioGroup>
+    <RadioGroup labelText="Single option" defaultValue="a">
+      <Radio value="a">Enabled</Radio>
+      <Radio value="b" disabled>Disabled</Radio>
+    </RadioGroup>
+  </div>
+</Preview>
+
+## Anatomy
+
+```tsx
+import { Radio, RadioGroup } from '@sipe-team/radio';
+
+export default () => (
+  <RadioGroup labelText="Label" defaultValue="a">
+    <Radio value="a">Option A</Radio>
+    <Radio value="b">Option B</Radio>
+  </RadioGroup>
+);
+```
+
+`RadioGroup` renders a `<fieldset>` (with a `<legend>` when `labelText` is set) and provides context;
+each `Radio` reads from it and renders a `<label>` wrapping an `<input type="radio">`. The selected
+value, `name`, `size`, and `disabled` live on `RadioGroup` — a `Radio` should be rendered inside one
+so the options share a group.
+
+## API Reference
+
+Neither part forwards a `ref`.
+
+### `RadioGroup`
+
+Renders a `<fieldset>`. Provides the selection, `name`, `size`, and `disabled` to its `Radio`
+children through context.
+
+| Prop            | Type                             | Default    | Description                                                              |
+| --------------- | -------------------------------- | ---------- | ------------------------------------------------------------------------ |
+| `children`      | `ReactNode`                      | —          | Required. The `Radio` options.                                           |
+| `value`         | `string`                         | —          | Controlled selected value. Pair with `onChangeValue`.                    |
+| `defaultValue`  | `string`                         | —          | Initial selected value when uncontrolled.                                |
+| `onChangeValue` | `(value: string) => void`        | —          | Called with the next value when a `Radio` is chosen.                     |
+| `labelText`     | `string`                         | `''`       | Rendered as the fieldset's `<legend>`. Omitted when empty.               |
+| `name`          | `string`                         | auto       | Shared `name` for the inputs. Generated via `useId` when not provided.   |
+| `size`          | `'small' \| 'medium' \| 'large'` | `'medium'` | Scales the dot, font size, and spacing of every option.                  |
+| `disabled`      | `boolean`                        | `false`    | Disables the whole group via `<fieldset disabled>`.                      |
+| `className`     | `string`                         | —          | Appended to the fieldset class.                                          |
+
+Extra props are not spread onto the `<fieldset>`; only those above are used.
+
+### `Radio`
+
+Renders a `<label>` wrapping an `<input type="radio">`, plus a `<span>` for the label text when
+`children` are given. Reads the selected value, `name`, `size`, and group `disabled` from
+`RadioGroup`.
+
+| Prop             | Type                             | Default        | Description                                                          |
+| ---------------- | -------------------------------- | -------------- | ------------------------------------------------------------------- |
+| `value`          | `string`                         | —              | Required. This option's value, compared against the group's value.  |
+| `children`       | `ReactNode`                      | —              | Label text. When omitted, no `<span>` is rendered.                  |
+| `size`           | `'small' \| 'medium' \| 'large'` | group / `'medium'` | Overrides the group `size` for this option.                    |
+| `disabled`       | `boolean`                        | `false`        | Disables just this option. The group `disabled` also forces it on.  |
+| `defaultChecked` | `boolean`                        | —              | Marks this option checked when uncontrolled. Usually prefer `RadioGroup`'s `defaultValue`. |
+| `className`      | `string`                         | —              | Appended to the `<label>` (container) class.                        |
+
+Also accepts the rest of `ComponentProps<'input'>` except `size` (`onChange`, `required`, `id`, …),
+spread onto the underlying `<input>`. `name` and `checked` are supplied by `RadioGroup`.
+
+## Accessibility
+
+- `RadioGroup` renders a native `<fieldset>`; `labelText` becomes its `<legend>`, labelling the group
+  for screen readers.
+- Each `Radio` is a native `<input type="radio">` sharing the group's `name`, so the browser provides
+  roving focus and arrow-key navigation between options for free.
+- Every `Radio` wraps its `<input>` in a `<label>` with a matching generated `id`, so clicking the
+  label selects the option.
+- `disabled` sets the native `disabled` attribute (on the `<fieldset>` for the group, or the `<input>`
+  for a single option).
+
+## Known limitations
+
+- `RadioGroup` always stacks its options vertically (`flex-direction: column`); there is no
+  `orientation` prop for a horizontal layout.
+- The `<legend>` is rendered without the component's styles, so `labelText` shows in the browser's
+  default legend styling rather than a token-driven treatment.

--- a/www/docs/components/radio.mdx
+++ b/www/docs/components/radio.mdx
@@ -16,6 +16,15 @@ export const ControlledRadio = () => {
   );
 };
 
+{/* Radio uses hardcoded light-surface colors, so it needs a light backdrop to be legible on the
+    dark-only docs stage. This wrapper is presentational only and is intentionally left out of the
+    `code` strings below. */}
+export const LightStage = ({ children }) => (
+  <div style={{ background: '#ffffff', padding: '1.5rem', borderRadius: '8px', width: '100%', boxSizing: 'border-box' }}>
+    {children}
+  </div>
+);
+
 # Radio
 
 A grouped single-choice control — a `RadioGroup` that owns the selected value, wrapping one `Radio`
@@ -44,11 +53,13 @@ rest. Clicking a `Radio`'s label selects it.
   <Radio value="grape">Grape</Radio>
 </RadioGroup>`}
 >
-  <RadioGroup labelText="Pick a fruit" defaultValue="orange">
-    <Radio value="apple">Apple</Radio>
-    <Radio value="orange">Orange</Radio>
-    <Radio value="grape">Grape</Radio>
-  </RadioGroup>
+  <LightStage>
+    <RadioGroup labelText="Pick a fruit" defaultValue="orange">
+      <Radio value="apple">Apple</Radio>
+      <Radio value="orange">Orange</Radio>
+      <Radio value="grape">Grape</Radio>
+    </RadioGroup>
+  </LightStage>
 </Preview>
 
 ## Examples
@@ -65,10 +76,12 @@ options are still submitted as a single field.
   <Radio value="express">Express</Radio>
 </RadioGroup>`}
 >
-  <RadioGroup labelText="Shipping" defaultValue="standard">
-    <Radio value="standard">Standard</Radio>
-    <Radio value="express">Express</Radio>
-  </RadioGroup>
+  <LightStage>
+    <RadioGroup labelText="Shipping" defaultValue="standard">
+      <Radio value="standard">Standard</Radio>
+      <Radio value="express">Express</Radio>
+    </RadioGroup>
+  </LightStage>
 </Preview>
 
 ### Controlled
@@ -85,7 +98,9 @@ the selection. `onChangeValue` receives the next value string.
   <Radio value="grape">Grape</Radio>
 </RadioGroup>`}
 >
-  <ControlledRadio />
+  <LightStage>
+    <ControlledRadio />
+  </LightStage>
 </Preview>
 
 ### Sizes
@@ -107,20 +122,22 @@ the selection. `onChangeValue` receives the next value string.
   <Radio value="b">Option B</Radio>
 </RadioGroup>`}
 >
-  <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
-    <RadioGroup size="small" labelText="Small" defaultValue="a">
-      <Radio value="a">Option A</Radio>
-      <Radio value="b">Option B</Radio>
-    </RadioGroup>
-    <RadioGroup size="medium" labelText="Medium" defaultValue="a">
-      <Radio value="a">Option A</Radio>
-      <Radio value="b">Option B</Radio>
-    </RadioGroup>
-    <RadioGroup size="large" labelText="Large" defaultValue="a">
-      <Radio value="a">Option A</Radio>
-      <Radio value="b">Option B</Radio>
-    </RadioGroup>
-  </div>
+  <LightStage>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+      <RadioGroup size="small" labelText="Small" defaultValue="a">
+        <Radio value="a">Option A</Radio>
+        <Radio value="b">Option B</Radio>
+      </RadioGroup>
+      <RadioGroup size="medium" labelText="Medium" defaultValue="a">
+        <Radio value="a">Option A</Radio>
+        <Radio value="b">Option B</Radio>
+      </RadioGroup>
+      <RadioGroup size="large" labelText="Large" defaultValue="a">
+        <Radio value="a">Option A</Radio>
+        <Radio value="b">Option B</Radio>
+      </RadioGroup>
+    </div>
+  </LightStage>
 </Preview>
 
 ### Disabled
@@ -138,16 +155,18 @@ a single `Radio` disables just that one. Both dim the affected labels.
   <Radio value="b" disabled>Disabled</Radio>
 </RadioGroup>`}
 >
-  <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
-    <RadioGroup labelText="Whole group" disabled defaultValue="a">
-      <Radio value="a">Selected but disabled</Radio>
-      <Radio value="b">Also disabled</Radio>
-    </RadioGroup>
-    <RadioGroup labelText="Single option" defaultValue="a">
-      <Radio value="a">Enabled</Radio>
-      <Radio value="b" disabled>Disabled</Radio>
-    </RadioGroup>
-  </div>
+  <LightStage>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+      <RadioGroup labelText="Whole group" disabled defaultValue="a">
+        <Radio value="a">Selected but disabled</Radio>
+        <Radio value="b">Also disabled</Radio>
+      </RadioGroup>
+      <RadioGroup labelText="Single option" defaultValue="a">
+        <Radio value="a">Enabled</Radio>
+        <Radio value="b" disabled>Disabled</Radio>
+      </RadioGroup>
+    </div>
+  </LightStage>
 </Preview>
 
 ## Anatomy
@@ -222,7 +241,8 @@ spread onto the underlying `<input>`. `name` and `checked` are supplied by `Radi
 
 ## Known limitations
 
+- Radio uses hardcoded light-surface colors (`constants/colors.ts`) rather than theme-driven tokens,
+  so it does not adapt to this dark-only docs site. The demos above are shown on a light card so the
+  control renders as intended; on a dark background its text would be illegible.
 - `RadioGroup` always stacks its options vertically (`flex-direction: column`); there is no
   `orientation` prop for a horizontal layout.
-- The `<legend>` is rendered without the component's styles, so `labelText` shows in the browser's
-  default legend styling rather than a token-driven treatment.

--- a/www/package.json
+++ b/www/package.json
@@ -25,6 +25,7 @@
     "@sipe-team/button": "workspace:*",
     "@sipe-team/checkbox": "workspace:*",
     "@sipe-team/icon": "workspace:*",
+    "@sipe-team/radio": "workspace:*",
     "@sipe-team/tokens": "workspace:*",
     "@sipe-team/typography": "workspace:*",
     "clsx": "^2.0.0",


### PR DESCRIPTION
## Changes

Radio를 문서로 추가하면서, 문서를 쓰다 드러난 컴포넌트 버그 1개를 같은 PR에서 고칩니다.

**`packages/radio` 버그 수정** (`@sipe-team/radio`: patch)
- **미적용 legend 스타일**: `Radio.css.ts`에 `radioGroupLegend` 스타일(굵기 600·16px·marginBottom 8px·토큰 색)이 정의돼 있었지만 `RadioGroup.tsx`의 `<legend>{labelText}</legend>`에 className이 붙지 않아, 그룹 라벨이 **브라우저 기본 스타일**로 렌더됐습니다. `<legend className={radioGroupLegend}>`로 연결해 의도한 스타일이 실제로 적용되게 했습니다. (죽어 있던 export를 살리는 변경이라 부작용 없음)

**`radio.mdx`**
- Installation / Usage / Examples / Anatomy / API Reference. API 표는 소스를 직접 읽고 수동 작성.
- `RadioGroup` + `Radio` 플랫 export 구조(네임스페이스 아님)를 문서화. Uncontrolled / Controlled(value + onChangeValue) / Sizes(small·medium·large) / Disabled(그룹·개별) 예제.
- 각 `<Preview code={...}>` 예제 코드는 실제 렌더 결과와 일치.

## Visuals
<img width="1541" height="931" alt="스크린샷 2026-07-23 오후 11 32 22" src="https://github.com/user-attachments/assets/28678a0e-5435-4cd8-9879-8e474d4c4b8b" />

## Checklist
- [x] Have you written the functional specifications? — 문서 자체가 명세
- [x] Have you written the test code? — 패키지 테스트 15개 통과. 문서는 프로덕션 빌드로 검증

## Additional Discussion Points
- 브랜치 카테고리는 `docs`지만 컴포넌트 fix를 포함합니다. changeset 포함(patch).
