### PR TITLE
feat(flex): clarify numeric responsive gap values

### DIFF
--- a/packages/flex/src/Flex.test.tsx
+++ b/packages/flex/src/Flex.test.tsx
@@ -293,6 +293,20 @@ describe('Flex', () => {
       expect(flexContainer.style.getPropertyValue('--side-flex-gap-lg')).toBe('24px');
     });
 
+    it('adds pixel units to non-zero numeric responsive gap values', () => {
+      render(
+        <Flex data-testid="flex-container" gap={{ sm: 8, md: 16, lg: 0 }}>
+          <div>item 1</div>
+          <div>item 2</div>
+        </Flex>,
+      );
+
+      const flexContainer = screen.getByTestId('flex-container');
+      expect(flexContainer.style.getPropertyValue('--side-flex-gap-sm')).toBe('8px');
+      expect(flexContainer.style.getPropertyValue('--side-flex-gap-md')).toBe('16px');
+      expect(flexContainer.style.getPropertyValue('--side-flex-gap-lg')).toBe('0');
+    });
+
     it('keeps nested responsive gap values independent from the parent Flex', () => {
       render(
         <Flex data-testid="parent-flex" gap={{ sm: '8px' }}>

--- a/packages/flex/src/Flex.tsx
+++ b/packages/flex/src/Flex.tsx
@@ -51,6 +51,10 @@ function getResponsiveClassNames<T extends string>(
   });
 }
 
+function normalizeResponsiveGapValue(value: CSSProperties['gap']) {
+  return typeof value === 'number' && value !== 0 ? `${value}px` : value;
+}
+
 function getResponsiveGapStyle(gap: FlexProps['gap']) {
   if (!isResponsiveValue(gap)) {
     return {
@@ -59,9 +63,9 @@ function getResponsiveGapStyle(gap: FlexProps['gap']) {
     };
   }
 
-  const sm = gap.sm ?? 'normal';
-  const md = gap.md ?? sm;
-  const lg = gap.lg ?? md;
+  const sm = normalizeResponsiveGapValue(gap.sm ?? 'normal');
+  const md = normalizeResponsiveGapValue(gap.md ?? sm);
+  const lg = normalizeResponsiveGapValue(gap.lg ?? md);
 
   return {
     className: styles.responsiveGap,


### PR DESCRIPTION
## 작업 내용

- responsive `gap`에 숫자 값을 사용할 때 scalar `gap`과 동일한 CSS 길이 규칙을 적용하도록 동작을 명확히 했습니다.
- `0`은 그대로 유지하고, 0이 아닌 숫자는 CSS custom property에 저장하기 전에 `px` 단위로 정규화합니다.
- 숫자형 responsive `gap`의 `sm`, `md`, `lg` 동작을 확인하는 회귀 테스트를 추가했습니다.

## 확인

- `./node_modules/.bin/vitest run packages/flex/src/Flex.test.tsx` (59 tests)
- `./node_modules/.bin/tsc --noEmit -p packages/flex/tsconfig.json`
- `./node_modules/.bin/biome lint packages/flex/src/Flex.tsx packages/flex/src/Flex.test.tsx`
- `./node_modules/.bin/tsup` (`packages/flex`)
- `git diff --check`
