### PR TITLE
docs(www): add Badge, Card, Divider docs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1193,6 +1193,9 @@ importers:
       '@sipe-team/button':
         specifier: workspace:*
         version: link:../packages/button
+      '@sipe-team/card':
+        specifier: workspace:*
+        version: link:../packages/card
       '@sipe-team/checkbox':
         specifier: workspace:*
         version: link:../packages/checkbox

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1199,6 +1199,9 @@ importers:
       '@sipe-team/checkbox':
         specifier: workspace:*
         version: link:../packages/checkbox
+      '@sipe-team/divider':
+        specifier: workspace:*
+        version: link:../packages/divider
       '@sipe-team/icon':
         specifier: workspace:*
         version: link:../packages/icon

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1187,6 +1187,9 @@ importers:
       '@sipe-team/avatar':
         specifier: workspace:*
         version: link:../packages/avatar
+      '@sipe-team/badge':
+        specifier: workspace:*
+        version: link:../packages/badge
       '@sipe-team/button':
         specifier: workspace:*
         version: link:../packages/button

--- a/www/docs/components/badge.mdx
+++ b/www/docs/components/badge.mdx
@@ -1,0 +1,89 @@
+---
+sidebar_label: Badge
+---
+
+import { Badge } from '@sipe-team/badge';
+
+# Badge
+
+A small inline label for statuses, counts, or short pieces of metadata.
+
+## Installation
+
+```sh
+npm install @sipe-team/badge
+```
+
+```ts
+import '@sipe-team/badge/styles.css';
+```
+
+## Usage
+
+Wrap the text you want to label. The badge sizes itself to its content.
+
+<Preview
+  code={`<Badge>New</Badge>`}
+>
+  <Badge>New</Badge>
+</Preview>
+
+## Examples
+
+### Variant
+
+`filled` (default) is the solid emphasis look; `outline` keeps only a border for a lighter touch;
+`weak` uses a muted neutral background.
+
+<Preview
+  code={`<Badge variant="filled">filled</Badge>
+<Badge variant="outline">outline</Badge>
+<Badge variant="weak">weak</Badge>`}
+>
+  <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap', alignItems: 'center' }}>
+    <Badge variant="filled">filled</Badge>
+    <Badge variant="outline">outline</Badge>
+    <Badge variant="weak">weak</Badge>
+  </div>
+</Preview>
+
+### Size
+
+`medium` (default) suits most inline uses; step up to `large` for emphasis, down to `small` for
+dense layouts. The text size scales with the badge (12 / 14 / 18 px).
+
+<Preview
+  code={`<Badge size="small">small</Badge>
+<Badge size="medium">medium</Badge>
+<Badge size="large">large</Badge>`}
+>
+  <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap', alignItems: 'center' }}>
+    <Badge size="small">small</Badge>
+    <Badge size="medium">medium</Badge>
+    <Badge size="large">large</Badge>
+  </div>
+</Preview>
+
+## Anatomy
+
+```tsx
+import { Badge } from '@sipe-team/badge';
+
+export default () => <Badge size="medium" variant="filled">New</Badge>;
+```
+
+Renders a `<div role="status">` wrapping the `children` in a `Typography` `<span>`.
+
+## API Reference
+
+Renders a `<div>` and forwards its `ref`.
+
+| Prop       | Type                                  | Default    | Description                          |
+| ---------- | ------------------------------------- | ---------- | ------------------------------------ |
+| `children` | `ReactNode`                           | —          | The badge's content, rendered as text. |
+| `size`     | `'small' \| 'medium' \| 'large'`      | `'medium'` | Padding and text size.               |
+| `variant`  | `'filled' \| 'outline' \| 'weak'`     | `'filled'` | Visual emphasis.                     |
+
+Also accepts every `ComponentProps<'div'>` (`className`, `onClick`, …), forwarded to the rendered
+`<div>`. The `<div>` carries `role="status"`, so screen readers announce its content as a live
+status message.

--- a/www/docs/components/badge.mdx
+++ b/www/docs/components/badge.mdx
@@ -23,9 +23,9 @@ import '@sipe-team/badge/styles.css';
 Wrap the text you want to label. The badge sizes itself to its content.
 
 <Preview
-  code={`<Badge>New</Badge>`}
+  code={`<Badge>사이프</Badge>`}
 >
-  <Badge>New</Badge>
+  <Badge>사이프</Badge>
 </Preview>
 
 ## Examples

--- a/www/docs/components/card.mdx
+++ b/www/docs/components/card.mdx
@@ -1,0 +1,111 @@
+---
+sidebar_label: Card
+---
+
+import { Card } from '@sipe-team/card';
+
+# Card
+
+A container that groups related content into a surface, with a fixed aspect ratio.
+
+## Installation
+
+```sh
+npm install @sipe-team/card
+```
+
+```ts
+import '@sipe-team/card/styles.css';
+```
+
+## Usage
+
+Give the card a width; its height follows from the `ratio`. Content is centered inside it.
+
+<Preview
+  code={`<Card style={{ width: 300 }}>Card</Card>`}
+>
+  <Card style={{ width: 300 }}>Card</Card>
+</Preview>
+
+## Examples
+
+### Variant
+
+`filled` (default) sits on a subtle background with a soft border; `outline` uses the default
+background with a stronger border; `ghost` is transparent with no border or padding.
+
+<Preview
+  code={`<Card variant="filled" style={{ width: 200 }}>filled</Card>
+<Card variant="outline" style={{ width: 200 }}>outline</Card>
+<Card variant="ghost" style={{ width: 200 }}>ghost</Card>`}
+>
+  <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap', alignItems: 'center' }}>
+    <Card variant="filled" style={{ width: 200 }}>filled</Card>
+    <Card variant="outline" style={{ width: 200 }}>outline</Card>
+    <Card variant="ghost" style={{ width: 200 }}>ghost</Card>
+  </div>
+</Preview>
+
+### Ratio
+
+The card's height is derived from its width via `aspect-ratio`. `rectangle` (default) is 16:9;
+`square` is 1:1; `wide` is 21:9; `portrait` is 3:4; `auto` lets the content size the height.
+
+<Preview
+  code={`<Card ratio="rectangle" style={{ width: 160 }}>16:9</Card>
+<Card ratio="square" style={{ width: 160 }}>1:1</Card>
+<Card ratio="wide" style={{ width: 160 }}>21:9</Card>
+<Card ratio="portrait" style={{ width: 160 }}>3:4</Card>
+<Card ratio="auto" style={{ width: 160 }}>auto</Card>`}
+>
+  <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap', alignItems: 'flex-start' }}>
+    <Card ratio="rectangle" style={{ width: 160 }}>16:9</Card>
+    <Card ratio="square" style={{ width: 160 }}>1:1</Card>
+    <Card ratio="wide" style={{ width: 160 }}>21:9</Card>
+    <Card ratio="portrait" style={{ width: 160 }}>3:4</Card>
+    <Card ratio="auto" style={{ width: 160 }}>auto</Card>
+  </div>
+</Preview>
+
+### `asChild`
+
+Drops the wrapping `div` and merges the card's styling onto the element it renders, so the card
+becomes a single element — here, an `<a>`.
+
+<Preview
+  code={`<Card asChild ratio="square" style={{ width: 160 }}>
+  <a href="#card">Link card</a>
+</Card>`}
+>
+  <Card asChild ratio="square" style={{ width: 160 }}>
+    <a href="#card">Link card</a>
+  </Card>
+</Preview>
+
+## Anatomy
+
+```tsx
+import { Card } from '@sipe-team/card';
+
+export default () => (
+  <Card variant="filled" ratio="rectangle" style={{ width: 300 }}>
+    Content
+  </Card>
+);
+```
+
+Renders a single `<div role="presentation">` that centers its `children`.
+
+## API Reference
+
+Renders a `<div>` (or the child element when `asChild` is set) and forwards its `ref`.
+
+| Prop       | Type                                                          | Default       | Description                                              |
+| ---------- | ------------------------------------------------------------- | ------------- | -------------------------------------------------------- |
+| `variant`  | `'filled' \| 'outline' \| 'ghost'`                            | `'filled'`    | Surface style — background, border, and padding.         |
+| `ratio`    | `'rectangle' \| 'square' \| 'wide' \| 'portrait' \| 'auto'`   | `'rectangle'` | `aspect-ratio` used to derive height from width.         |
+| `asChild`  | `boolean`                                                     | `false`       | Merge props onto the child instead of rendering a `div`. |
+
+Also accepts every `ComponentProps<'div'>` (`className`, `style`, `onClick`, …), forwarded to the
+rendered element. The element carries `role="presentation"`.

--- a/www/docs/components/divider.mdx
+++ b/www/docs/components/divider.mdx
@@ -1,0 +1,103 @@
+---
+sidebar_label: Divider
+---
+
+import { Divider } from '@sipe-team/divider';
+
+# Divider
+
+A thin rule that separates content, horizontally or vertically.
+
+## Installation
+
+```sh
+npm install @sipe-team/divider
+```
+
+```ts
+import '@sipe-team/divider/styles.css';
+```
+
+## Usage
+
+A horizontal divider fills the width of its container.
+
+<Preview
+  code={`<Divider />`}
+>
+  <div style={{ width: '100%' }}>
+    <Divider />
+  </div>
+</Preview>
+
+## Examples
+
+### Orientation
+
+`horizontal` (default) is a full-width line; `vertical` is a full-height line, so place it inside a
+container that has a height (for example, a flex row).
+
+<Preview
+  code={`<div style={{ height: 40, display: 'flex', alignItems: 'center' }}>
+  <span>Left</span>
+  <Divider orientation="vertical" style={{ margin: '0 16px' }} />
+  <span>Right</span>
+</div>`}
+>
+  <div style={{ height: 40, display: 'flex', alignItems: 'center' }}>
+    <span>Left</span>
+    <Divider orientation="vertical" style={{ margin: '0 16px' }} />
+    <span>Right</span>
+  </div>
+</Preview>
+
+### Color
+
+`default` is a subtle gray; `primary` uses the brand cyan; `dark` is a strong near-black.
+
+Because `dark` is near-black, it is intended for light surfaces — on a dark background it blends
+in. The panel below is kept light so all three colors stay visible regardless of the page theme.
+
+<Preview
+  code={`<Divider color="default" />
+<Divider color="primary" />
+<Divider color="dark" />`}
+>
+  <div
+    style={{
+      width: '100%',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '1rem',
+      background: '#fff',
+      padding: '1.5rem',
+      borderRadius: '8px',
+    }}
+  >
+    <Divider color="default" />
+    <Divider color="primary" />
+    <Divider color="dark" />
+  </div>
+</Preview>
+
+## Anatomy
+
+```tsx
+import { Divider } from '@sipe-team/divider';
+
+export default () => <Divider orientation="horizontal" color="default" />;
+```
+
+Renders a single `<hr>` with `aria-orientation` set to match `orientation`.
+
+## API Reference
+
+Renders an `<hr>` and forwards its `ref`.
+
+| Prop          | Type                          | Default        | Description                                                      |
+| ------------- | ----------------------------- | -------------- | ---------------------------------------------------------------- |
+| `orientation` | `'horizontal' \| 'vertical'`  | `'horizontal'` | Line direction. `horizontal` is full-width; `vertical` is full-height. |
+| `color`       | `'default' \| 'primary' \| 'dark'` | `'default'` | Line color.                                                      |
+
+Also accepts every `ComponentProps<'hr'>` (`className`, `style`, …), forwarded to the `<hr>`.
+Override `style` for custom thickness, dashes, or color.

--- a/www/package.json
+++ b/www/package.json
@@ -26,6 +26,7 @@
     "@sipe-team/button": "workspace:*",
     "@sipe-team/card": "workspace:*",
     "@sipe-team/checkbox": "workspace:*",
+    "@sipe-team/divider": "workspace:*",
     "@sipe-team/icon": "workspace:*",
     "@sipe-team/input": "workspace:*",
     "@sipe-team/radio": "workspace:*",

--- a/www/package.json
+++ b/www/package.json
@@ -24,6 +24,7 @@
     "@sipe-team/avatar": "workspace:*",
     "@sipe-team/badge": "workspace:*",
     "@sipe-team/button": "workspace:*",
+    "@sipe-team/card": "workspace:*",
     "@sipe-team/checkbox": "workspace:*",
     "@sipe-team/icon": "workspace:*",
     "@sipe-team/input": "workspace:*",

--- a/www/package.json
+++ b/www/package.json
@@ -22,6 +22,7 @@
     "@mdx-js/react": "^3.0.0",
     "@sipe-team/accordion": "workspace:*",
     "@sipe-team/avatar": "workspace:*",
+    "@sipe-team/badge": "workspace:*",
     "@sipe-team/button": "workspace:*",
     "@sipe-team/checkbox": "workspace:*",
     "@sipe-team/icon": "workspace:*",


### PR DESCRIPTION
## Changes
<!-- Please briefly describe the changes. -->
Badge, Card, Divider 컴포넌트의 문서를 추가합니다.
컴포넌트의 변경사항은 없어 changeset 작성은 생략합니다.

## Visuals
<!-- If there are any screenshots or visual materials, please attach them. -->

### Badge
<img width="1962" height="5406" alt="localhost_3000_docs_components_badge" src="https://github.com/user-attachments/assets/9744391d-031e-400e-82c5-244a8615b90b" />

### Card
<img width="1880" height="7404" alt="localhost_3000_docs_components_badge (1)" src="https://github.com/user-attachments/assets/377d0463-4adc-44d8-9e79-7cdcd5fe75ab" />

### Divider
<img width="1952" height="5482" alt="localhost_3000_docs_components_divider" src="https://github.com/user-attachments/assets/4601566e-ebf6-452a-9963-5c577ad415ab" />


## Checklist
- [ ] Have you written the functional specifications?
- [ ] Have you written the test code?

## Additional Discussion Points
<!-- If there are any additional points to be aware of, please specify them. -->
