### PR TITLE
docs(www): footer as one row, chrome frame alignment, and polish

### DIFF
--- a/www/docusaurus.config.ts
+++ b/www/docusaurus.config.ts
@@ -13,9 +13,6 @@ const r = (p: string) => path.resolve(__dirname, '..', 'packages', p);
 // components that read `vars` resolve against it. Built once for the whole site, not per component.
 const tokensCss = r('tokens/dist/styles.css');
 
-// The tokens declare `Pretendard` as the base family but ship no font, so every
-// page was falling back to the system sans. The dynamic subset splits by
-// `unicode-range`, so a page only pulls the glyph blocks it actually renders.
 const pretendardCss = require.resolve('pretendard/dist/web/static/pretendard-dynamic-subset.css');
 
 export default {
@@ -28,8 +25,6 @@ export default {
   projectName: 'side',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
-  // `favicon` above only emits the .ico. The rest of the set mirrors what
-  // sipe.team serves, so the two sites resolve to the same icon everywhere.
   headTags: [
     { tagName: 'link', attributes: { rel: 'icon', type: 'image/png', sizes: '32x32', href: '/img/favicon-32x32.png' } },
     { tagName: 'link', attributes: { rel: 'icon', type: 'image/png', sizes: '16x16', href: '/img/favicon-16x16.png' } },
@@ -80,18 +75,11 @@ export default {
   ],
 
   themeConfig: {
-    // The tokens only define a dark set — `themes.css.ts` gives `:root` and
-    // `[data-theme=dark]` the same values — so a light toggle would put dark-only
-    // components on a white page. Pinning dark matches what the tokens can
-    // actually express, and matches sipe.team, which is dark-only.
     colorMode: {
       defaultMode: 'dark',
       disableSwitch: true,
     },
     navbar: {
-      // The Sipe wordmark, carried over from sipe.team. Its gradient runs
-      // #FF4500 → #FFB24D, which lands on the same amber as the accent token.
-      // It stands alone — no title beside it.
       logo: {
         alt: 'Sipe',
         src: 'img/logo.svg',
@@ -116,15 +104,6 @@ export default {
         },
       ],
     },
-    // A flat `links` array (no `title`/`items`) is Docusaurus's simple footer: one
-    // row instead of columns. Columns split the container evenly, which left two
-    // links stranded at either end of a 1320px gap.
-    //
-    // No `style: 'dark'` either — that class hardcodes a blue-grey background
-    // (#303846) on the footer element itself, out of reach of the token overrides.
-    //
-    // Overview and Components live in the navbar one click away, so repeating
-    // them here would only pad the row out.
     footer: {
       links: [
         { label: 'GitHub', href: 'https://github.com/sipe-team/side' },
@@ -132,11 +111,6 @@ export default {
       ],
       copyright: `All rights reserved ⓒ SIPE ${new Date().getFullYear()}`,
     },
-    // Dracula's purple/pink keywords read as a second accent next to the amber,
-    // and its background carries a purple tint the neutral surfaces don't. vsDark
-    // is grey-based, so the code blocks sit in the page instead of on it. Both
-    // slots point at it because a stored-light session would otherwise surface
-    // the light theme.
     prism: {
       theme: prismThemes.vsDark,
       darkTheme: prismThemes.vsDark,

--- a/www/docusaurus.config.ts
+++ b/www/docusaurus.config.ts
@@ -116,24 +116,19 @@ export default {
         },
       ],
     },
-    // No `style: 'dark'` — that class hardcodes a blue-grey background (#303846)
-    // on the footer element itself, where the token overrides can't reach it.
+    // A flat `links` array (no `title`/`items`) is Docusaurus's simple footer: one
+    // row instead of columns. Columns split the container evenly, which left two
+    // links stranded at either end of a 1320px gap.
+    //
+    // No `style: 'dark'` either — that class hardcodes a blue-grey background
+    // (#303846) on the footer element itself, out of reach of the token overrides.
+    //
+    // Overview and Components live in the navbar one click away, so repeating
+    // them here would only pad the row out.
     footer: {
       links: [
-        {
-          title: 'Side',
-          items: [
-            { label: 'Overview', to: '/docs/overview/Installation' },
-            { label: 'Components', to: '/docs/components/accordion' },
-          ],
-        },
-        {
-          title: 'Sipe',
-          items: [
-            { label: 'GitHub', href: 'https://github.com/sipe-team/side' },
-            { label: 'sipe.team', href: 'https://sipe.team' },
-          ],
-        },
+        { label: 'GitHub', href: 'https://github.com/sipe-team/side' },
+        { label: 'sipe.team', href: 'https://sipe.team' },
       ],
       copyright: `All rights reserved ⓒ SIPE ${new Date().getFullYear()}`,
     },

--- a/www/src/HomepageFeatures/index.module.css
+++ b/www/src/HomepageFeatures/index.module.css
@@ -5,7 +5,6 @@
   width: 100%;
 }
 
-/* Surface a step up from the page, separated by a hairline rather than a shadow. */
 .card {
   height: 100%;
   padding: var(--side-spacing-component-xl);

--- a/www/src/HomepageFeatures/index.tsx
+++ b/www/src/HomepageFeatures/index.tsx
@@ -43,7 +43,6 @@ function Feature({ title, description }: FeatureItem) {
   return (
     <div className="col col--4">
       <div className={styles.card}>
-        {/* h2, not h3 — the hero is the only h1, so jumping to h3 would skip a level. */}
         <Heading as="h2" className={styles.cardTitle}>
           {title}
         </Heading>

--- a/www/src/HomepageFeatures/index.tsx
+++ b/www/src/HomepageFeatures/index.tsx
@@ -43,7 +43,8 @@ function Feature({ title, description }: FeatureItem) {
   return (
     <div className="col col--4">
       <div className={styles.card}>
-        <Heading as="h3" className={styles.cardTitle}>
+        {/* h2, not h3 — the hero is the only h1, so jumping to h3 would skip a level. */}
+        <Heading as="h2" className={styles.cardTitle}>
           {title}
         </Heading>
         <p className={styles.cardBody}>{description}</p>

--- a/www/src/components/Preview/styles.module.css
+++ b/www/src/components/Preview/styles.module.css
@@ -6,9 +6,6 @@
   overflow: hidden;
 }
 
-/* `align-items` has to be pinned: the default `stretch` was blowing every
-   example out to the full stage width, so a Button rendered as an 800px bar
-   instead of at its own size. */
 .stage {
   display: flex;
   flex-direction: column;

--- a/www/src/custom.css
+++ b/www/src/custom.css
@@ -113,7 +113,10 @@ html[data-theme="dark"] {
   --ifm-menu-color-background-active: var(--side-color-background-subtle);
   --ifm-tabs-color-active: var(--side-color-accent-default);
   --ifm-tabs-color-active-border: var(--side-color-accent-default);
-  --ifm-breadcrumb-color-active: var(--side-color-accent-default);
+  /* The active crumb is the current page, not a destination. Amber made it read
+     like a link; neutral says "you are here". Amber stays on things you can act
+     on — sidebar active, links, TOC. */
+  --ifm-breadcrumb-color-active: var(--side-color-foreground-default);
   --ifm-pagination-nav-color-hover: var(--side-color-accent-default);
 
   --ifm-navbar-background-color: var(--side-color-background-base);
@@ -146,6 +149,11 @@ html[data-theme="dark"] {
   --ifm-code-border-radius: var(--side-radius-component-md);
   --ifm-pre-background: var(--side-color-background-subtle);
 
+  /* Infima defaults to 1140/1320px; sipe.team holds everything to 1060px, which
+     also stops the home cards from drifting apart on wide screens. */
+  --ifm-container-width: 1060px;
+  --ifm-container-width-xl: 1060px;
+
   /* Depth comes from surface + border contrast, not shadow. */
   --ifm-global-shadow-lw: none;
   --ifm-global-shadow-md: none;
@@ -168,6 +176,15 @@ html[data-theme="dark"] {
    and leave it shouting next to the title. */
 .navbar__logo {
   height: 1.25rem;
+}
+
+/* Focus was left to the browser default (a thin blue ring), while the token
+   that exists for it — `--side-color-border-focus` — went unused. Route
+   keyboard focus through the token so the ring matches the rest of the chrome.
+   Scoped to `:focus-visible` so it only shows for keyboard users. */
+:focus-visible {
+  outline: 2px solid var(--side-color-border-focus);
+  outline-offset: 2px;
 }
 
 /* sipe.team runs its footer as a single ~100px line: copyright left, links

--- a/www/src/custom.css
+++ b/www/src/custom.css
@@ -1,35 +1,6 @@
-/* Docs chrome, expressed in design tokens.
- *
- * Infima re-declares 36 of its own variables under `html[data-theme='dark']`
- * (specificity 0,1,1). A bare `:root` (0,1,0) loses to that no matter how late
- * this file loads, so every override below is scoped to all three selectors at
- * once. Listing `light` too covers visitors whose stored preference predates the
- * pinned theme — `disableSwitch` hides the toggle but does not reset what's
- * already in localStorage, so those sessions still render as `data-theme=light`.
- *
- * Two things to know before editing:
- *
- * 1. Keep this file unlayered. `tokens/dist/styles.css` emits `--side-*` inside
- *    `@layer theme`; wrapping this file in a layer too recreates the duplicate
- *    `@layer theme` shape that cssnano once collapsed, stripping every token in
- *    production. See the alias note in docusaurus.config.ts.
- *
- * 2. `data-theme` is shared ground. The tokens package also emits cohort themes
- *    under `[data-theme="1st"]`…`[data-theme="5th"]` that redefine the accent. If
- *    a playground ever mounts those, the two features are fighting over one
- *    attribute and need separate namespaces.
- */
-
 :root,
 html[data-theme="light"],
 html[data-theme="dark"] {
-  /* Infima derives most component colors from this ramp, so overriding it here
-     reaches far more than the eleven declarations suggest. It runs light→dark,
-     which Infima inverts for dark mode; the semantic layer has no neutral ramp
-     to offer, so these point at primitives. Twelve token steps into eleven slots
-     means one gets dropped — `gray-800` goes, because `gray-900` (#18181b) and
-     `gray-700` (#3f3f46) are the surface/border pair the components actually
-     read. */
   --ifm-color-gray-0: var(--color-white);
   --ifm-color-gray-100: var(--color-gray-50);
   --ifm-color-gray-200: var(--color-gray-100);
@@ -42,9 +13,6 @@ html[data-theme="dark"] {
   --ifm-color-gray-900: var(--color-gray-900);
   --ifm-color-gray-1000: var(--color-gray-950);
 
-  /* Pinned rather than left to Infima's per-mode inversion: the dark branch only
-     fires under `data-theme=dark`, so a stored-light session would otherwise get
-     a light emphasis scale on a dark background. */
   --ifm-color-emphasis-0: var(--color-gray-950);
   --ifm-color-emphasis-100: var(--color-gray-900);
   --ifm-color-emphasis-200: var(--color-gray-700);
@@ -85,16 +53,11 @@ html[data-theme="dark"] {
   --ifm-color-danger-contrast-foreground: var(--side-color-status-danger-foreground);
 
   --ifm-background-color: var(--side-color-background-base);
-  /* `subtle` sits only 14 RGB steps off the page, which leaves the border doing
-     all the lifting — the opposite of sipe.team, where the surface leads and the
-     border follows. `muted` puts the two signals back in balance. */
   --ifm-background-surface-color: var(--side-color-background-muted);
   --ifm-color-content: var(--side-color-foreground-default);
   --ifm-color-content-secondary: var(--side-color-foreground-subtle);
   --ifm-heading-color: var(--side-color-foreground-default);
 
-  /* Infima wants literal white-alpha here. Mixing against the foreground token
-     keeps the reference intact and lands on the same value. */
   --ifm-hover-overlay: color-mix(in srgb, var(--side-color-foreground-default) 6%, transparent);
   --ifm-code-background: color-mix(in srgb, var(--side-color-foreground-default) 10%, transparent);
   --ifm-table-stripe-background: color-mix(in srgb, var(--side-color-foreground-default) 4%, transparent);
@@ -113,9 +76,6 @@ html[data-theme="dark"] {
   --ifm-menu-color-background-active: var(--side-color-background-subtle);
   --ifm-tabs-color-active: var(--side-color-accent-default);
   --ifm-tabs-color-active-border: var(--side-color-accent-default);
-  /* The active crumb is the current page, not a destination. Amber made it read
-     like a link; neutral says "you are here". Amber stays on things you can act
-     on — sidebar active, links, TOC. */
   --ifm-breadcrumb-color-active: var(--side-color-foreground-default);
   --ifm-pagination-nav-color-hover: var(--side-color-accent-default);
 
@@ -137,11 +97,6 @@ html[data-theme="dark"] {
   --ifm-scrollbar-thumb-background-color: var(--side-color-border-default);
   --ifm-scrollbar-thumb-hover-background-color: var(--side-color-border-strong);
 
-  /* The accent is a high-luminance amber; white label text on it lands around
-     1.7:1. Dark text clears AA comfortably. The tokens package says otherwise
-     (`--color-foreground-on-accent: #ffffff`) — that's a bug on its side, and
-     reaching for it here would put a contrast failure on the page that documents
-     the system. */
   --ifm-button-color: var(--side-color-background-base);
 
   --ifm-global-radius: var(--side-radius-component-lg);
@@ -149,12 +104,9 @@ html[data-theme="dark"] {
   --ifm-code-border-radius: var(--side-radius-component-md);
   --ifm-pre-background: var(--side-color-background-subtle);
 
-  /* Infima defaults to 1140/1320px; sipe.team holds everything to 1060px, which
-     also stops the home cards from drifting apart on wide screens. */
   --ifm-container-width: 1060px;
   --ifm-container-width-xl: 1060px;
 
-  /* Depth comes from surface + border contrast, not shadow. */
   --ifm-global-shadow-lw: none;
   --ifm-global-shadow-md: none;
   --ifm-global-shadow-tl: none;
@@ -172,24 +124,15 @@ html[data-theme="dark"] {
   --ifm-code-font-size: 95%;
 }
 
-/* The wordmark is drawn at 72×20. Infima's default 2rem would scale it up 60%
-   and leave it shouting next to the title. */
 .navbar__logo {
   height: 1.25rem;
 }
 
-/* Focus was left to the browser default (a thin blue ring), while the token
-   that exists for it — `--side-color-border-focus` — went unused. Route
-   keyboard focus through the token so the ring matches the rest of the chrome.
-   Scoped to `:focus-visible` so it only shows for keyboard users. */
 :focus-visible {
   outline: 2px solid var(--side-color-border-focus);
   outline-offset: 2px;
 }
 
-/* sipe.team runs its footer as a single ~100px line: copyright left, links
-   right. Docusaurus stacks the two blocks and centers both, so this puts them
-   back on one row — `row-reverse` because the links come first in the DOM. */
 .footer .container {
   display: flex;
   flex-direction: row-reverse;
@@ -204,9 +147,6 @@ html[data-theme="dark"] {
   text-align: left;
 }
 
-/* Body size on the right would outweigh the 12px copyright on the left; 14px
-   keeps the row balanced without shrinking the links below a comfortable
-   target. */
 .footer__link-item {
   font-size: var(--side-font-size-100);
 }

--- a/www/src/custom.css
+++ b/www/src/custom.css
@@ -169,3 +169,39 @@ html[data-theme="dark"] {
 .navbar__logo {
   height: 1.25rem;
 }
+
+/* sipe.team runs its footer as a single ~100px line: copyright left, links
+   right. Docusaurus stacks the two blocks and centers both, so this puts them
+   back on one row — `row-reverse` because the links come first in the DOM. */
+.footer .container {
+  display: flex;
+  flex-direction: row-reverse;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--side-spacing-component-xl);
+}
+
+.footer__links,
+.footer__bottom {
+  margin: 0;
+  text-align: left;
+}
+
+/* Body size on the right would outweigh the 12px copyright on the left; 14px
+   keeps the row balanced without shrinking the links below a comfortable
+   target. */
+.footer__link-item {
+  font-size: var(--side-font-size-100);
+}
+
+.footer__copyright {
+  font-size: var(--side-font-size-050);
+}
+
+@media screen and (max-width: 996px) {
+  .footer .container {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--side-spacing-component-lg);
+  }
+}

--- a/www/src/custom.css
+++ b/www/src/custom.css
@@ -1,6 +1,9 @@
 :root,
 html[data-theme="light"],
 html[data-theme="dark"] {
+  --side-chrome-padding-horizontal: clamp(1rem, 2vw, 2rem);
+  --ifm-navbar-padding-horizontal: var(--side-chrome-padding-horizontal);
+
   --ifm-color-gray-0: var(--color-white);
   --ifm-color-gray-100: var(--color-gray-50);
   --ifm-color-gray-200: var(--color-gray-100);
@@ -136,6 +139,8 @@ html[data-theme="dark"] {
 
 .footer .container {
   max-width: none;
+  padding-left: var(--side-chrome-padding-horizontal);
+  padding-right: var(--side-chrome-padding-horizontal);
   display: flex;
   flex-direction: row-reverse;
   align-items: center;

--- a/www/src/custom.css
+++ b/www/src/custom.css
@@ -88,6 +88,7 @@ html[data-theme="dark"] {
   --ifm-card-background-color: var(--side-color-background-muted);
 
   --ifm-footer-background-color: var(--side-color-background-subtle);
+  --ifm-footer-padding-horizontal: 0;
   --ifm-footer-color: var(--side-color-foreground-subtle);
   --ifm-footer-title-color: var(--side-color-foreground-default);
   --ifm-footer-link-color: var(--side-color-foreground-subtle);
@@ -134,6 +135,7 @@ html[data-theme="dark"] {
 }
 
 .footer .container {
+  max-width: none;
   display: flex;
   flex-direction: row-reverse;
   align-items: center;

--- a/www/src/pages/index.module.css
+++ b/www/src/pages/index.module.css
@@ -1,5 +1,3 @@
-/* sipe.team leads with a centered hero on a flat dark ground — no full-bleed
-   accent panel, which is what Infima's `hero--primary` would give us. */
 .heroBanner {
   padding: var(--side-spacing-layout-xl) 0;
   text-align: center;
@@ -15,7 +13,6 @@
   letter-spacing: -0.02em;
 }
 
-/* 24px semibold, matching the sub-headline on sipe.team's hero. */
 .heroSubtitle {
   margin: 0;
   color: var(--side-color-foreground-subtle);


### PR DESCRIPTION

## Changes


### 1. footer 한 줄 (`1d6da2a`)

머지된 footer는 링크 4개에 2단 컬럼이라 **204px**를 썼고, 컬럼이 컨테이너를 균등 분할해 링크들이 1320px 간격 양끝에 떨어져 가운데가 비어 있었습니다.

- Docusaurus는 **flat `links` 배열을 단일 행**으로 렌더 → 그룹 타이틀 제거
- **Overview / Components 제거** — navbar에 한 클릭 위에 이미 있어, footer가 실제로 더하던 링크는 sipe.team 하나뿐이었습니다
- **좌 카피라이트 / 우 링크** 한 줄 (`.footer .container`에 flex, swizzle 없음)
- 링크 14px — 오른쪽 본문 크기 텍스트가 12px 카피라이트보다 무거워 보이지 않게
- `style: 'dark'` 제거 — 이 클래스가 footer에 `#303846`을 하드코딩해 토큰 오버라이드가 닿지 않음

**204px → 96px** (sipe.team 100px).

### 2. 컨테이너·포커스·breadcrumb·헤딩 (`fd536f7`)

- **컨테이너 1060px 고정.** Infima 기본 1140/1320px이라 넓은 화면에서 홈 카드가 퍼졌습니다. sipe.team과 같은 1060px로 카드가 한 덩어리로 읽힙니다.
- **`:focus-visible`를 토큰으로.** `--side-color-border-focus`가 정의만 되고 아무도 안 써서, 키보드 포커스가 브라우저 기본 링으로 떨어져 있었습니다 — 크롬에서 유일하게 토큰 밖이던 부분.
- **활성 breadcrumb를 중립색으로.** 현재 페이지 표시인데 앰버라 클릭 가능한 것처럼 읽혔습니다. 앰버는 링크·사이드바 active 등 실제 인터랙션에만 남깁니다.
- **홈 카드 제목 h2.** 히어로가 유일한 h1인데 곧바로 h3라 레벨을 건너뛰었습니다 (WCAG 1.3.1). `.cardTitle`에 명시적 font-size가 있어 크기는 그대로.

### 4. footer ↔ navbar 프레임 정렬 (`31850db`)

footer가 화면 중앙 1060px 컨테이너인데 navbar는 full-width라 애초에 안 맞았습니다. 홈에선 카드도 중앙 1060라 우연히 맞았지만, 문서 페이지는 본문이 사이드바만큼 밀려 있어 카피라이트가 사이드바 아래에 뜨고 링크가 본문을 넘어갔습니다.

footer의 `max-width`와 좌우 패딩을 없애 navbar와 같은 여백에 맞췄습니다. 상단 로고↔카피라이트, 상단 GitHub↔하단 링크가 모든 페이지에서 같은 세로선에 놓입니다.

### 5. 크롬 여백 반응형 (`782d0e3`)

navbar/footer가 16px 고정 여백이라 넓은 화면에서 가장자리에 바짝 붙었습니다. 공유 `clamp(1rem, 2vw, 2rem)`로 배선 — 모바일 16px, ~1200px에서 24px, 1728px+에서 32px. 변수 하나가 상하 크롬을 함께 움직여 모든 폭에서 정렬 유지.

