### PR TITLE
docs(www): document Chip

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1254,6 +1254,9 @@ importers:
       '@sipe-team/checkbox':
         specifier: workspace:*
         version: link:../packages/checkbox
+      '@sipe-team/chip':
+        specifier: workspace:*
+        version: link:../packages/chip
       '@sipe-team/divider':
         specifier: workspace:*
         version: link:../packages/divider

--- a/www/docs/components/chip.mdx
+++ b/www/docs/components/chip.mdx
@@ -1,0 +1,212 @@
+---
+sidebar_label: Chip
+---
+
+import { useState } from 'react';
+import { Chip } from '@sipe-team/chip';
+
+{/* Chip hardcodes light-surface colors (e.g. outline text is `gray700`), so it needs a light backdrop
+    to be legible on the dark-only docs stage. This wrapper is presentational only and is intentionally
+    left out of the `code` strings below. */}
+export const LightStage = ({ children }) => (
+  <div style={{ background: '#ffffff', padding: '1.5rem', borderRadius: '8px', width: '100%', boxSizing: 'border-box' }}>
+    {children}
+  </div>
+);
+
+export const SelectableChips = () => {
+  const [selected, setSelected] = useState('react');
+  const options = ['react', 'vue', 'svelte'];
+  return (
+    <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+      {options.map((option) => (
+        <Chip key={option} selected={selected === option} onClick={() => setSelected(option)}>
+          {option}
+        </Chip>
+      ))}
+    </div>
+  );
+};
+
+# Chip
+
+A compact, pill-shaped `<button>` for tags, filters, and single-choice selections.
+
+## Installation
+
+```sh
+npm install @sipe-team/chip
+```
+
+```ts
+import '@sipe-team/chip/styles.css';
+```
+
+## Usage
+
+A `Chip` renders a native `<button>` with a fully rounded, pill shape. It is `primary`, `filled`, and
+`medium` by default.
+
+<Preview
+  code={`<Chip>SIPE chip</Chip>`}
+>
+  <LightStage>
+    <Chip>SIPE chip</Chip>
+  </LightStage>
+</Preview>
+
+## Examples
+
+### Colors
+
+`color` sets the palette. All five colors are themed for the default `filled` variant.
+
+<Preview
+  code={`<Chip color="primary">Primary</Chip>
+<Chip color="secondary">Secondary</Chip>
+<Chip color="success">Success</Chip>
+<Chip color="warning">Warning</Chip>
+<Chip color="danger">Danger</Chip>`}
+>
+  <LightStage>
+    <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+      <Chip color="primary">Primary</Chip>
+      <Chip color="secondary">Secondary</Chip>
+      <Chip color="success">Success</Chip>
+      <Chip color="warning">Warning</Chip>
+      <Chip color="danger">Danger</Chip>
+    </div>
+  </LightStage>
+</Preview>
+
+### Variants
+
+`filled` (default) has a solid background; `outline` is transparent with a colored border.
+
+<Preview
+  code={`<Chip variant="filled">Filled</Chip>
+<Chip variant="outline">Outline</Chip>`}
+>
+  <LightStage>
+    <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+      <Chip variant="filled">Filled</Chip>
+      <Chip variant="outline">Outline</Chip>
+    </div>
+  </LightStage>
+</Preview>
+
+### Sizes
+
+`medium` (default) suits most rows; `small` for dense layouts, `large` for prominent tags. Padding,
+font size, and height scale together.
+
+<Preview
+  code={`<Chip size="small">Small</Chip>
+<Chip size="medium">Medium</Chip>
+<Chip size="large">Large</Chip>`}
+>
+  <LightStage>
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px', alignItems: 'center' }}>
+      <Chip size="small">Small</Chip>
+      <Chip size="medium">Medium</Chip>
+      <Chip size="large">Large</Chip>
+    </div>
+  </LightStage>
+</Preview>
+
+### Selected
+
+`selected` switches a chip to its highlighted state — a `primary` chip turns cyan. `Chip` does not own
+this state, so drive it from the parent (e.g. a `useState`) to build filter or single-choice groups.
+
+<Preview
+  code={`const [selected, setSelected] = useState('react');
+const options = ['react', 'vue', 'svelte'];
+
+<div style={{ display: 'flex', gap: '8px' }}>
+  {options.map((option) => (
+    <Chip key={option} selected={selected === option} onClick={() => setSelected(option)}>
+      {option}
+    </Chip>
+  ))}
+</div>`}
+>
+  <LightStage>
+    <SelectableChips />
+  </LightStage>
+</Preview>
+
+### Disabled
+
+The native `disabled` attribute is forwarded to the `<button>` and dims the chip to 40% opacity.
+
+<Preview
+  code={`<Chip disabled>Disabled</Chip>
+<Chip variant="outline" disabled>Disabled</Chip>`}
+>
+  <LightStage>
+    <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+      <Chip disabled>Disabled</Chip>
+      <Chip variant="outline" disabled>Disabled</Chip>
+    </div>
+  </LightStage>
+</Preview>
+
+### `asChild`
+
+Render as a different element (e.g. a link) while keeping the chip's styles.
+
+<Preview
+  code={`<Chip asChild>
+  <a href="#aschild">Link chip</a>
+</Chip>`}
+>
+  <LightStage>
+    <Chip asChild>
+      <a href="#aschild">Link chip</a>
+    </Chip>
+  </LightStage>
+</Preview>
+
+## Anatomy
+
+```tsx
+import { Chip } from '@sipe-team/chip';
+
+export default () => (
+  <Chip color="primary" variant="filled" size="medium">
+    Label
+  </Chip>
+);
+```
+
+Renders a single native `<button>`. With `asChild`, the styles and props are merged onto the child
+element you provide instead.
+
+## API Reference
+
+Renders a `<button>` and forwards its `ref`.
+
+| Prop        | Type                                                          | Default     | Description                                                        |
+| ----------- | ------------------------------------------------------------ | ----------- | ----------------------------------------------------------------- |
+| `children`  | `ReactNode`                                                  | —           | The chip label.                                                   |
+| `color`     | `'primary' \| 'secondary' \| 'success' \| 'warning' \| 'danger'` | `'primary'` | Color palette.                                                    |
+| `variant`   | `'filled' \| 'outline'`                                      | `'filled'`  | Solid background vs. transparent with a colored border.           |
+| `size`      | `'small' \| 'medium' \| 'large'`                             | `'medium'`  | Padding, font size, and height.                                   |
+| `selected`  | `boolean`                                                    | `false`     | Highlighted state. Controlled by the parent.                      |
+| `asChild`   | `boolean`                                                    | `false`     | Merge props onto the child instead of rendering a `button`.       |
+
+Also accepts every `ComponentProps<'button'>` (`disabled`, `onClick`, `type`, …), forwarded to the
+rendered element.
+
+## Known limitations
+
+- Chip hardcodes light-surface colors (from `@sipe-team/tokens`) rather than theme-aware tokens, so it
+  does not adapt to this dark-only docs site. The demos above are shown on a light card so the chip
+  renders as intended; on a dark background the `outline` variant's text would be illegible.
+- The `color` × `variant` × `selected` matrix is only partially themed. `selected` is styled for
+  `primary`/`secondary` `filled` chips and for `primary`/`success`/`warning`/`danger` `outline` chips;
+  other combinations (e.g. `secondary` `outline`, or `success`/`warning`/`danger` `filled` when
+  selected) fall back to unstyled defaults. Stick to the combinations shown above.
+- `Chip` provides no built-in selection, toggle, or removal behavior — it is a styled `<button>`. Wire
+  up `onClick` and drive `selected` yourself.

--- a/www/package.json
+++ b/www/package.json
@@ -26,6 +26,7 @@
     "@sipe-team/button": "workspace:*",
     "@sipe-team/card": "workspace:*",
     "@sipe-team/checkbox": "workspace:*",
+    "@sipe-team/chip": "workspace:*",
     "@sipe-team/divider": "workspace:*",
     "@sipe-team/icon": "workspace:*",
     "@sipe-team/input": "workspace:*",


### PR DESCRIPTION
## Changes

Chip을 문서로 추가합니다. 컴포넌트 변경 없이 문서만 추가하는 PR입니다.

**`chip.mdx`**
- Installation / Usage / Examples / Anatomy / API Reference. API 표는 소스를 직접 읽고 수동 작성.
- `Chip`은 네이티브 `<button>`. `color`(primary/secondary/success/warning/danger) · `variant`(filled/outline) · `size`(small/medium/large) · `selected` · `asChild` · 네이티브 `disabled`(40% opacity)를 문서화.
- 예제: Usage / Colors / Variants / Sizes / Selected(useState 필터 데모, SSR-safe) / Disabled / asChild. 각 `<Preview code={...}>` 예제 코드는 실제 렌더 결과와 일치.
- **다크 사이트 대응:** Chip은 텍스트색을 라이트 표면 기준으로 하드코딩(`gray700`)해서 다크 stage에서 안 보입니다. 따라서 각 데모를 라이트 카드로 감쌌습니다(머지된 Radio 문서와 동일한 `LightStage` 패턴). `code` 문자열엔 wrapper 미포함.
 스킵.

## Known limitations (문서에 명시)

- `color × variant × selected` 스타일 매트릭스가 **불완전**합니다: filled selected는 primary/secondary만, outline은 secondary가 없음 → 일부 조합(secondary outline, success/warning/danger filled-selected)이 스타일 없이 렌더됩니다. 예제는 지원되는 조합만 사용하고 이 한계를 문서에 표기했습니다. (컴포넌트 소스는 건드리지 않음)

## Visuals
<img width="1338" height="1130" alt="스크린샷 2026-07-27 오후 11 00 13" src="https://github.com/user-attachments/assets/f070d9d6-70f2-4953-ab2a-80641faca0b6" />

## Checklist
- [x] Have you written the functional specifications? — 문서 자체가 명세
- [ ] Have you written the test code? — 문서 전용 PR이라 유닛 테스트 없음. 프로덕션 빌드로 검증
