### PR TITLE
chore(checkbox): useId를 @sipe-team/hooks로 교체

### DIFF
--- a/.changeset/checkbox-shared-use-id.md
+++ b/.changeset/checkbox-shared-use-id.md
@@ -1,0 +1,5 @@
+---
+"@sipe-team/checkbox": patch
+---
+
+Source Checkbox's internal `id` from `@sipe-team/hooks`'s `useId` instead of calling React's `useId` directly. The `props.id ?? internalId` fallback pattern is now handled by `useId`'s `deterministicId` argument. Behavior is unchanged aside from the generated id now carrying a `side-` prefix when no `id` prop is passed.

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -21,6 +21,7 @@
     "clean": "rm -rf node_modules dist"
   },
   "dependencies": {
+    "@sipe-team/hooks": "workspace:*",
     "@sipe-team/tokens": "workspace:*",
     "clsx": "catalog:",
     "@vanilla-extract/recipes": "catalog:"

--- a/packages/checkbox/src/Checkbox.tsx
+++ b/packages/checkbox/src/Checkbox.tsx
@@ -1,12 +1,6 @@
-import {
-  type ChangeEventHandler,
-  type ComponentProps,
-  createContext,
-  forwardRef,
-  type Ref,
-  useContext,
-  useId,
-} from 'react';
+import { type ChangeEventHandler, type ComponentProps, createContext, forwardRef, type Ref, useContext } from 'react';
+
+import { useId } from '@sipe-team/hooks';
 
 import clsx from 'clsx';
 
@@ -54,8 +48,7 @@ const Root = forwardRef<HTMLInputElement, CheckBoxRootBaseProps>(
     },
     ref,
   ) => {
-    const internalId = useId();
-    const id = props.id ?? internalId;
+    const id = useId(props.id);
 
     const [checkedState, setCheckedState] = useControllableState<boolean | undefined>({
       prop: checked,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -452,6 +452,9 @@ importers:
 
   packages/checkbox:
     dependencies:
+      '@sipe-team/hooks':
+        specifier: workspace:*
+        version: link:../hooks
       '@sipe-team/tokens':
         specifier: workspace:*
         version: link:../tokens


### PR DESCRIPTION
## 요약

Checkbox의 내부 id 생성 방식을 React의 raw `useId` 대신 `@sipe-team/hooks`의 `useId`로 교체합니다. Tooltip(#319), Radio/RadioGroup(#320)에 이어 Accordion에 적용된 공유 훅과 동일한 패턴으로 통일하기 위함입니다. 기존 `props.id ?? internalId` fallback 패턴은 `useId`의 `deterministicId` 인자가 동일하게 처리하므로 `const id = useId(props.id);` 한 줄로 대체했습니다. `id` prop을 명시적으로 넘기지 않을 때 생성되는 id에 `side-` 접두어가 붙는 것 외에 동작 변화는 없습니다.

## 변경 사항

- `Checkbox.tsx`의 `useId` import를 `react`에서 `@sipe-team/hooks`로 교체
- `const internalId = useId(); const id = props.id ?? internalId;`를 `const id = useId(props.id);`로 축약
- `@sipe-team/checkbox` 패키지에 `@sipe-team/hooks` 의존성 추가
- patch changeset 추가
